### PR TITLE
Minor improvements in handling

### DIFF
--- a/utilix/config.py
+++ b/utilix/config.py
@@ -20,20 +20,18 @@ class Config():
     def __init__(self):
         if not Config.instance:
             Config.instance = Config.__Config()
-
     def __getattr__(self, name):
         return getattr(self.instance, name)
 
     class __Config(configparser.ConfigParser):
 
         def __init__(self):
-
             config_file_path = os.path.join(os.environ['HOME'], '.xenonnt.conf')
             logger.debug('Loading configuration from %s' % (config_file_path))
-
             configparser.ConfigParser.__init__(self, interpolation=EnvInterpolation())
+
             try:
-                self.readfp(open(config_file_path), 'r')
+                self.read_file(open(config_file_path), 'r')
             except FileNotFoundError as e:
                 raise RuntimeError(
                     'Unable to open %s. Please see the README for an example configuration' % (config_file_path)) from e

--- a/utilix/rundb.py
+++ b/utilix/rundb.py
@@ -5,6 +5,7 @@ import datetime
 import logging
 from utilix.config import Config
 
+#Config the logger:
 logger = logging.getLogger("utilix")
 ch = logging.StreamHandler()
 ch.setLevel(logging.ERROR)
@@ -12,9 +13,8 @@ formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(messag
 ch.setFormatter(formatter)
 logger.addHandler(ch)
 
+#Config Utilix
 config = Config()
-
-
 PREFIX = config.get('RunDB', 'rundb_api_url')
 BASE_HEADERS = {'Content-Type': "application/json", 'Cache-Control': "no-cache"}
 
@@ -173,11 +173,13 @@ class Token:
             json.dump(self.json, f)
 
 
-class DB:
+class DB():
     """Wrapper around the RunDB API"""
 
-    def __init__(self, token_path=os.path.join(os.environ['HOME'], ".dbtoken")):
+    def __init__(self):
         # Takes a path to serialized token object
+
+        token_path = os.path.join(os.environ['HOME'], ".dbtoken")
         token = Token(token_path)
 
         self.headers = BASE_HEADERS.copy()
@@ -190,6 +192,11 @@ class DB:
         self.set_run = False
         self.selector = 'number'
         self.select = None
+
+    def config(self, ):
+        print(url)
+        print(user)
+        print(password)
 
     def set_run_number(self, run_number, detector='tpc'):
         # Generalize your number vs. name approach to fix the input
@@ -273,6 +280,12 @@ class DB:
         url = '/run/{selector}/{num}/data/'.format(selector=self.selector, num=self.select)
         return self._delete(url, data=data_field)
 
+    def replace_data(self, data_field_old=None, data_field_new=None):
+        if data_field_new == None or data_field_old == None:
+            return 0
+        delete_test = self.delete_data(data_field_old)
+        update_test = self.update_data(data_field_new)
+        ##Todo: What would be a good return here?
 
 # for testing
 def test():

--- a/utilix/rundb.py
+++ b/utilix/rundb.py
@@ -99,7 +99,7 @@ class DB:
         # Generalize your number vs. name approach to fix the input
         self.run_number = run_number
         self.run_detector = detector
-        self.run_name = self.get_name(self.run_number, detector=detector)
+        self.run_name = self._get_name(self.run_number, detector=detector)
         self.set_run = True
         self._setup()
 
@@ -107,7 +107,7 @@ class DB:
         # Generalize your number vs. name approach to fix the input
         self.run_name = run_name
         self.run_detector = detector
-        self.run_number = self.get_number(self.run_name, detector=detector)
+        self.run_number = self._get_number(self.run_name, detector=detector)
         self.set_run = True
         self._setup()
 
@@ -140,13 +140,12 @@ class DB:
             self.selector='number'
             self.select=self.run_number
 
-    def get_name(self, number=None, detector='tpc'):
-        # TODO check against the detector, if necessary
+    def _get_name(self, number=None, detector='tpc'):
         url = "/runs/number/{number}/filter/detector".format(number=number)
         response = json.loads(self._get(url).text)
         return response['results']['name']
 
-    def get_number(self, name=None, detector='tpc'):
+    def _get_number(self, name=None, detector='tpc'):
         url = "/runs/name/{name}/filter/detector".format(name=name)
         response = json.loads(self._get(url).text)
         return response['results']['number']
@@ -160,18 +159,18 @@ class DB:
         url = '/runs/{selector}/{num}'.format(selector=self.selector, num=self.select)
         return json.loads(self._get(url).text)['results']['data']
 
-    def get_data1(self):
+    def get_plugin_locations(self):
         url = '/runs/{selector}/{num}/data/dids'.format(selector=self.selector, num=self.select)
-        print(self._get(url).text)
-        return json.loads(self._get(url).text)['results']
+        return json.loads(self._get(url).text)['results']['dids']
 
     def update_data(self, datum):
+        datum = json.dump(datum)
         print(datum)
         url = '/run/{selector}/{num}/data/'.format(selector=self.selector, num=self.select)
         return self._post(url, data=datum)
 
     def delete_datum(self, datum):
-        datum = json.dumps(datum)
+        datum = json.dump(datum)
         url = '/run/{selector}/{num}/data/'.format(selector=self.selector, num=self.select)
         return self._delete(url, data=datum)
 

--- a/utilix/rundb.py
+++ b/utilix/rundb.py
@@ -6,12 +6,108 @@ import logging
 from utilix.config import Config
 
 logger = logging.getLogger("utilix")
+ch = logging.StreamHandler()
+ch.setLevel(logging.ERROR)
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+ch.setFormatter(formatter)
+logger.addHandler(ch)
 
 config = Config()
+
 
 PREFIX = config.get('RunDB', 'rundb_api_url')
 BASE_HEADERS = {'Content-Type': "application/json", 'Cache-Control': "no-cache"}
 
+def Responder(func):
+
+    def LookUp():
+        return_dict = {
+            #taken from https://github.com/kennethreitz/requests/blob/master/requests/status_codes.py
+            # Informational.
+            100: ('continue',),
+            101: ('switching_protocols',),
+            102: ('processing',),
+            103: ('checkpoint',),
+            122: ('uri_too_long', 'request_uri_too_long'),
+            200: ('ok', 'okay', 'all_ok', 'all_okay', 'all_good', '\\o/', '✓'),
+            201: ('created',),
+            202: ('accepted',),
+            203: ('non_authoritative_info', 'non_authoritative_information'),
+            204: ('no_content',),
+            205: ('reset_content', 'reset'),
+            206: ('partial_content', 'partial'),
+            207: ('multi_status', 'multiple_status', 'multi_stati', 'multiple_stati'),
+            208: ('already_reported',),
+            226: ('im_used',),
+
+            # Redirection.
+            300: ('multiple_choices',),
+            301: ('moved_permanently', 'moved', '\\o-'),
+            302: ('found',),
+            303: ('see_other', 'other'),
+            304: ('not_modified',),
+            305: ('use_proxy',),
+            306: ('switch_proxy',),
+            307: ('temporary_redirect', 'temporary_moved', 'temporary'),
+            308: ('permanent_redirect',
+                  'resume_incomplete', 'resume',),  # These 2 to be removed in 3.0
+
+            # Client Error.
+            400: ('bad_request', 'bad'),
+            401: ('unauthorized',),
+            402: ('payment_required', 'payment'),
+            403: ('forbidden',),
+            404: ('not_found', '-o-'),
+            405: ('method_not_allowed', 'not_allowed'),
+            406: ('not_acceptable',),
+            407: ('proxy_authentication_required', 'proxy_auth', 'proxy_authentication'),
+            408: ('request_timeout', 'timeout'),
+            409: ('conflict',),
+            410: ('gone',),
+            411: ('length_required',),
+            412: ('precondition_failed', 'precondition'),
+            413: ('request_entity_too_large',),
+            414: ('request_uri_too_large',),
+            415: ('unsupported_media_type', 'unsupported_media', 'media_type'),
+            416: ('requested_range_not_satisfiable', 'requested_range', 'range_not_satisfiable'),
+            417: ('expectation_failed',),
+            418: ('im_a_teapot', 'teapot', 'i_am_a_teapot'),
+            421: ('misdirected_request',),
+            422: ('unprocessable_entity', 'unprocessable'),
+            423: ('locked',),
+            424: ('failed_dependency', 'dependency'),
+            425: ('unordered_collection', 'unordered'),
+            426: ('upgrade_required', 'upgrade'),
+            428: ('precondition_required', 'precondition'),
+            429: ('too_many_requests', 'too_many'),
+            431: ('header_fields_too_large', 'fields_too_large'),
+            444: ('no_response', 'none'),
+            449: ('retry_with', 'retry'),
+            450: ('blocked_by_windows_parental_controls', 'parental_controls'),
+            451: ('unavailable_for_legal_reasons', 'legal_reasons'),
+            499: ('client_closed_request',),
+
+            # Server Error.
+            500: ('internal_server_error', 'server_error', '/o\\', '✗'),
+            501: ('not_implemented',),
+            502: ('bad_gateway',),
+            503: ('service_unavailable', 'unavailable'),
+            504: ('gateway_timeout',),
+            505: ('http_version_not_supported', 'http_version'),
+            506: ('variant_also_negotiates',),
+            507: ('insufficient_storage',),
+            509: ('bandwidth_limit_exceeded', 'bandwidth'),
+            510: ('not_extended',),
+            511: ('network_authentication_required', 'network_auth', 'network_authentication'),
+            }
+        return return_dict
+
+    def func_wrapper(*args, **kwargs):
+        st = func(*args, **kwargs)
+        if st.status_code != 200:
+            logger.error("HTTP(s) request says: {0} (Code {1})".format(LookUp()[st.status_code][0], st.status_code))
+        return st
+    return func_wrapper
 
 class Token:
     """
@@ -112,15 +208,19 @@ class DB:
         self._setup()
 
     #Helper:
+    @Responder
     def _get(self, url):
         return requests.get(PREFIX + url, headers=self.headers)
 
+    @Responder
     def _put(self, url, data):
         return requests.put(PREFIX + url, data, headers=self.headers)
 
+    @Responder
     def _post(self, url, data):
         return requests.post(PREFIX + url, data, headers=self.headers)
 
+    @Responder
     def _delete(self, url, data):
         return requests.delete(PREFIX + url, data=data, headers=self.headers)
 
@@ -163,16 +263,15 @@ class DB:
         url = '/runs/{selector}/{num}/data/dids'.format(selector=self.selector, num=self.select)
         return json.loads(self._get(url).text)['results']['dids']
 
-    def update_data(self, datum):
-        datum = json.dump(datum)
-        print(datum)
+    def update_data(self, data_field):
+        data_field = json.dumps(data_field)
         url = '/run/{selector}/{num}/data/'.format(selector=self.selector, num=self.select)
-        return self._post(url, data=datum)
+        return self._post(url, data=data_field)
 
-    def delete_datum(self, datum):
-        datum = json.dump(datum)
+    def delete_data(self, data_field):
+        data_field = json.dumps(data_field)
         url = '/run/{selector}/{num}/data/'.format(selector=self.selector, num=self.select)
-        return self._delete(url, data=datum)
+        return self._delete(url, data=data_field)
 
 
 # for testing

--- a/utilix/rundb.py
+++ b/utilix/rundb.py
@@ -185,7 +185,7 @@ class DB():
         self.headers = BASE_HEADERS.copy()
         self.headers['Authorization'] = "Bearer {token}".format(token=token())
 
-        #initialize some variables
+        #initialize some variables in the beginning
         self.run_number = None
         self.run_name = None
         self.run_detector = None
@@ -193,10 +193,6 @@ class DB():
         self.selector = 'number'
         self.select = None
 
-    def config(self, ):
-        print(url)
-        print(user)
-        print(password)
 
     def set_run_number(self, run_number, detector='tpc'):
         # Generalize your number vs. name approach to fix the input
@@ -247,6 +243,14 @@ class DB():
             self.selector='number'
             self.select=self.run_number
 
+    def _evaluator(self, run, detector):
+        # Evaluate if run is a run number int or string if
+        # set_run_number() or set_run_name() are not used!
+        if type(run) == int:
+            self.set_run_number(run_number=run, detector=detector)
+        elif type(run) == str:
+            self.set_run_name(run_name=run, detector=detector)
+
     def _get_name(self, number=None, detector='tpc'):
         url = "/runs/number/{number}/filter/detector".format(number=number)
         response = json.loads(self._get(url).text)
@@ -257,30 +261,43 @@ class DB():
         response = json.loads(self._get(url).text)
         return response['results']['number']
 
-    def get_doc(self):
+    def get_doc(self, run=None, detector=None):
+        if run != None:
+            self._evaluator(run, detector)
+
         # return the whole run doc for this run number
         url = '/runs/{selector}/{num}'.format(selector=self.selector, num=self.select)
         return json.loads(self._get(url).text)['results']
 
-    def get_data(self):
+    def get_data(self, run=None, detector=None):
+        if run != None:
+            self._evaluator(run, detector)
         url = '/runs/{selector}/{num}'.format(selector=self.selector, num=self.select)
         return json.loads(self._get(url).text)['results']['data']
 
-    def get_plugin_locations(self):
+    def get_plugin_locations(self, run=None, detector=None):
+        if run != None:
+            self._evaluator(run, detector)
         url = '/runs/{selector}/{num}/data/dids'.format(selector=self.selector, num=self.select)
         return json.loads(self._get(url).text)['results']['dids']
 
-    def update_data(self, data_field):
+    def update_data(self, data_field, run=None, detector=None):
+        if run != None:
+            self._evaluator(run, detector)
         data_field = json.dumps(data_field)
         url = '/run/{selector}/{num}/data/'.format(selector=self.selector, num=self.select)
         return self._post(url, data=data_field)
 
-    def delete_data(self, data_field):
+    def delete_data(self, data_field, run=None, detector=None):
+        if run != None:
+            self._evaluator(run, detector)
         data_field = json.dumps(data_field)
         url = '/run/{selector}/{num}/data/'.format(selector=self.selector, num=self.select)
         return self._delete(url, data=data_field)
 
-    def replace_data(self, data_field_old=None, data_field_new=None):
+    def replace_data(self, data_field_old=None, data_field_new=None, run=None, detector=None):
+        if run != None:
+            self._evaluator(run, detector)
         if data_field_new == None or data_field_old == None:
             return 0
         delete_test = self.delete_data(data_field_old)
@@ -294,6 +311,8 @@ def test():
     db_data = db.get_data()
     print("------")
     print(db_data)
+    print("as alternative:")
+    print(db.get_data(2000))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
  - I started to add some helpful http error messages for failing requests
  - Init & run number / run name selection is separated from each other
  - Interlock run name and run number (both are valid parameters after a cross check with the runDB
  - Focus on the data field: added a replace_data function to allow user to exchange a certain dictionary in the data 'list' by a new one

