### PR TITLE
Warn when not being able to get server_info

### DIFF
--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -1,0 +1,36 @@
+import utilix
+import pymongo
+
+uconfig = utilix.uconfig
+
+
+def test_mongo_urls_without_secondary_preferred(collection='runs', raise_errors=True, **kwargs):
+    """Test that we can do a naive initiation of the rundb"""
+    # Get the url for the config
+    uri = 'mongodb://{user}:{pw}@{url}'
+    url = uconfig.get('RunDB', 'pymongo_url')
+    user = uconfig.get('RunDB', 'pymongo_user')
+    pw = uconfig.get('RunDB', 'pymongo_password')
+    database = uconfig.get('RunDB', 'pymongo_database')
+    uri = uri.format(user=user, pw=pw, url=url)
+
+    # Do a naive client initialization
+    c = pymongo.MongoClient(uri, serverSelectionTimeoutMS=500, **kwargs)
+    DB = c[database]
+    coll = DB[collection]
+
+    # This test might fail! See the corresponding error message and:
+    # https://github.com/XENONnT/utilix/pull/14. The point of this test
+    # is to see if we can just plug the pymongo_url into a mongo client
+    # (often not the case depending on the access to one or more of the
+    # mirrors).
+    # If CI is ever integrated to Utilix, we should disable the
+    # raise_errors for this test.
+    utilix.rundb.test_collection(coll, url, raise_errors=raise_errors)
+
+
+def test_mongo_urls_secondary_preferred():
+    """Do it the right way, use secondary preferred"""
+    # Raise errors if this fails because then we have a big problem!
+    test_mongo_urls_without_secondary_preferred(
+        **dict(readPreference='secondaryPreferred'), raise_errors=True)

--- a/utilix/rundb.py
+++ b/utilix/rundb.py
@@ -429,7 +429,8 @@ def pymongo_collection(collection='runs', **kwargs):
         message = (
             f'Cannot get server info from "{url}". This usually happens when '
             f'trying to connect to multiple mirrors when they cannot decide '
-            f'which is primary. Also see:\n'
+            f'which is primary. Reading with readPreference="secondaryPreferred" '
+            f'should work. Also see:\n'
             f'https://github.com/XENONnT/straxen/pull/163#issuecomment-732031099')
         warn(message)
 

--- a/utilix/rundb.py
+++ b/utilix/rundb.py
@@ -403,16 +403,16 @@ class PyMongoCannotConnect(Exception):
     pass
 
 
-def test_collection(coll, url, raise_errors=False):
+def test_collection(collection, url, raise_errors=False):
     """
     Warn user if client can be troublesome if read preference is not specified
-    :param client: pymongo client
+    :param collection: pymongo client
     :param url: the mongo url we are testing (for the error message)
     :param raise_errors: if False (default) warn, otherwise raise an error
     """
     try:
         # test the collection by doing a light query
-        coll.find_one({}, {'_id': 1})
+        collection.find_one({}, {'_id': 1})
     except (pymongo.errors.ServerSelectionTimeoutError, pymongo.errors.OperationFailure) as e:
         # This happens when trying to connect to one or more mirrors
         # where we cannot decide on who is primary


### PR DESCRIPTION
We have recently seen that this can cause errors:
https://xenonnt.slack.com/archives/C016DM0JPK9/p1605866361323700

This can be avoided by the read-preference, therefore we may just raise a warning rather than an Error (what I did first). Let me know if you think this is still necessary. 