### PR TITLE
Check collection instead of client

### DIFF
--- a/utilix/rundb.py
+++ b/utilix/rundb.py
@@ -413,11 +413,10 @@ def test_collection(coll, url, raise_errors=False):
     try:
         # test the collection by doing a light query
         coll.find_one({}, {'_id': 1})
-    except pymongo.errors.ServerSelectionTimeoutError as e:
+    except (pymongo.errors.ServerSelectionTimeoutError, pymongo.errors.OperationFailure) as e:
         # This happens when trying to connect to one or more mirrors
         # where we cannot decide on who is primary
-        message = (f'Cannot get server info from "{url}". *Reading* with '
-                   f'readPreference="secondaryPreferred" should work. ')
+        message = (f'Cannot get server info from "{url}". Check your config at {uconfig.config_path}')
         if not raise_errors:
             warn(message)
         else:

--- a/utilix/rundb.py
+++ b/utilix/rundb.py
@@ -403,7 +403,7 @@ class PyMongoCannotConnect(Exception):
     pass
 
 
-def test_client(client, url, raise_errors=False):
+def test_collection(coll, url, raise_errors=False):
     """
     Warn user if client can be troublesome if read preference is not specified
     :param client: pymongo client
@@ -411,7 +411,8 @@ def test_client(client, url, raise_errors=False):
     :param raise_errors: if False (default) warn, otherwise raise an error
     """
     try:
-        client.server_info()
+        # test the collection by doing a light query
+        coll.find_one({}, {'_id': 1})
     except pymongo.errors.ServerSelectionTimeoutError as e:
         # This happens when trying to connect to one or more mirrors
         # where we cannot decide on who is primary
@@ -445,10 +446,12 @@ def pymongo_collection(collection='runs', **kwargs):
     if not database:
         database = uconfig.get('RunDB', 'pymongo_database')
     uri = uri.format(user=user, pw=pw, url=url)
-    c = pymongo.MongoClient(uri, readPreference='secondaryPreferred')
-    # Checkout the client we are returning and raise errors if you want
-    # to be realy sure we can use this URL.
-    test_client(c, url, raise_errors=False)
-
+    c = pymongo.MongoClient(uri, readPreference='secondaryPreferred',
+                            serverSelectionTimeoutMS=2000)
     DB = c[database]
-    return DB[collection]
+    coll = DB[collection]
+    # Checkout the collection we are returning and raise errors if you want
+    # to be realy sure we can use this URL.
+    test_collection(coll, url, raise_errors=False)
+    
+    return coll


### PR DESCRIPTION
Joran had the nice suggestion to perform a test of the mongo client in utilix so that we can give better error messages if needed. This is a slight modification of that to test the actual collection instead of the client, since I was having issues with the client checks. 

The main issue this is trying to solve is not really a utilix problem. For XENON, we need to pass `readPreference='secondaryPreferred'` to the pymongo client for things to work properly with our mirrors (or only pass a single accessible mirror, ie not LNGS). This flag gets passed automatically when using the `pymongo_collection` function of utilix; however, if someone is using the utilix config to setup a MongoClient without using this `pymongo_collection` function there could be problems if they don't pass the right arguments. But that is not a utilix problem and I don't think we should try to use utilix to debug such issues -- that gets a bit messy in my opinion. 

So in this PR a test is performed on the actual collection returned by `pymongo_collection` function, which is within the scope of utilix. I'm still not 100% convinced this is necessary, but it doesn't hurt to have. 
