### PR TITLE
Use github actions to pip install utilix

### DIFF
--- a/.github/workflows/Pipi.yml
+++ b/.github/workflows/Pipi.yml
@@ -1,18 +1,15 @@
-# From https://github.com/marketplace/actions/pypi-publish
-# This is a basic workflow to help you get started with Actions
+# Lets upload utilix to PyPi to make it pip instalable 
+# Mostly based on https://github.com/marketplace/actions/pypi-publish
 on:
   release:
     types: [published]
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+      # Setup steps
       - name: Setup python
         uses: actions/setup-python@v2
         with:
@@ -21,13 +18,12 @@ jobs:
         uses: actions/checkout@v2
       - name: Install dependencies
         run: pip install wheel
-      - name: Check the dir
-        run: |
-              ls 
       - name: Build package
         run: python setup.py sdist bdist_wheel
+      # Do the publish
       - name: Publish a Python distribution to PyPI
-        # Might want to add but does not work on workflow_dispatch if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        # Might want to add but does not work on workflow_dispatch :
+        # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@master
         with:
           user:  ${{ secrets.token }}

--- a/.github/workflows/Pipi.yml
+++ b/.github/workflows/Pipi.yml
@@ -14,7 +14,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Publish a Python distribution to PyPI
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        # Might want to add but does not work on workflow_dispatch if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@master
         with:
           user:  ${{ secrets.token }}

--- a/.github/workflows/Pipi.yml
+++ b/.github/workflows/Pipi.yml
@@ -13,10 +13,19 @@ jobs:
     runs-on: ubuntu-latest
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.6'
+      - name: Checkout repo
+        uses: actions/checkout@v2
       - name: Install dependencies
         run: pip install wheel
       - name: Go to dir
-        run: ls ; cd utilix ; ls
+        run: |
+              ls 
+              cd utilix/utilix
+              ls
       - name: Build package
         run: python setup.py sdist bdist_wheel
       - name: Publish a Python distribution to PyPI

--- a/.github/workflows/Pipi.yml
+++ b/.github/workflows/Pipi.yml
@@ -17,5 +17,5 @@ jobs:
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@master
         with:
-          user:  ${{ secrets.__token__ }}
+          user:  ${{ secrets.token }}
           password: ${{ secrets.pypi_password }}

--- a/.github/workflows/Pipi.yml
+++ b/.github/workflows/Pipi.yml
@@ -13,6 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+      - name: Install dependencies
+        run: pip install wheel
+      - name: Build package
+        run: python setup.py sdist bdist_wheel
       - name: Publish a Python distribution to PyPI
         # Might want to add but does not work on workflow_dispatch if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@master

--- a/.github/workflows/Pipi.yml
+++ b/.github/workflows/Pipi.yml
@@ -1,0 +1,21 @@
+# From https://github.com/marketplace/actions/pypi-publish
+# This is a basic workflow to help you get started with Actions
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - name: Publish a Python distribution to PyPI
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user:  ${{ secrets.__token__ }}
+          password: ${{ secrets.pypi_password }}

--- a/.github/workflows/Pipi.yml
+++ b/.github/workflows/Pipi.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Install dependencies
         run: pip install wheel
+      - name: Go to dir
+        run: ls ; cd utilix ; ls
       - name: Build package
         run: python setup.py sdist bdist_wheel
       - name: Publish a Python distribution to PyPI

--- a/.github/workflows/Pipi.yml
+++ b/.github/workflows/Pipi.yml
@@ -21,11 +21,9 @@ jobs:
         uses: actions/checkout@v2
       - name: Install dependencies
         run: pip install wheel
-      - name: Go to dir
+      - name: Check the dir
         run: |
               ls 
-              cd utilix/utilix
-              ls
       - name: Build package
         run: python setup.py sdist bdist_wheel
       - name: Publish a Python distribution to PyPI


### PR DESCRIPTION
Use github actions to install utilix. Fix issue https://github.com/XENONnT/utilix/issues/12

Straxens docs were failing due to utilix not being pip installable. That is a thing of the past with this PR. Will have to check that my secrets of my fork are also on the XenonnT repo.

**Result**
```pip install utilix```. Tada