### PR TITLE
Bug fix in token and add utilix.batchq 

### DIFF
--- a/utilix/batchq.py
+++ b/utilix/batchq.py
@@ -35,13 +35,12 @@ def singularity_wrap(jobstring, image, bind=('/dali', '/project2', TMPDIR)):
 
     bind_string = " ".join([f"--bind {b}" for b in bind])
     image = os.path.join(SINGULARITY_DIR, image)
-
+    jobstring = 'unset X509_CERT_DIR\n' + jobstring
     new_job_string = f"""cat > {exec_file} << EOF
 #!/bin/bash
 {jobstring}
 EOF
 singularity exec {bind_string} {image} {exec_file}
-echo 'Removing tmpfile'
 rm {exec_file}
 """
     return new_job_string

--- a/utilix/batchq.py
+++ b/utilix/batchq.py
@@ -1,0 +1,91 @@
+import subprocess
+import os
+import tempfile
+import shlex
+
+sbatch_template = """#!/bin/bash
+
+#SBATCH --job-name={jobname}
+#SBATCH --output={log}
+#SBATCH --error={log}
+#SBATCH --account=pi-lgrandi
+#SBATCH --qos={qos}
+#SBATCH --partition={partition}
+#SBATCH --mem-per-cpu={mem_per_cpu}
+#SBATCH --cpus-per-task={cpus_per_task}
+
+{job}
+"""
+
+SINGULARITY_DIR = '/project2/lgrandi/xenonnt/singularity-images'
+TMPDIR = os.path.join(os.environ.get('SCRATCH'), 'tmp')
+
+
+def make_executable(path):
+    """Make the file at path executable, see """
+    mode = os.stat(path).st_mode
+    mode |= (mode & 0o444) >> 2    # copy R bits to X
+    os.chmod(path, mode)
+
+
+def singularity_wrap(jobstring, image, bind=('/dali', '/project2', TMPDIR)):
+    """Wraps a jobscript into another executable file that can be passed to singularity exec"""
+    _, exec_file = tempfile.mkstemp(suffix='.sh', dir=TMPDIR)
+    make_executable(exec_file)
+
+    bind_string = " ".join([f"--bind {b}" for b in bind])
+    image = os.path.join(SINGULARITY_DIR, image)
+
+    new_job_string = f"""cat > {exec_file} << EOF
+#!/bin/bash
+{jobstring}
+EOF
+singularity exec {bind_string} {image} {exec_file}
+echo 'Removing tmpfile'
+rm {exec_file}
+"""
+    return new_job_string
+
+
+def submit_job(jobstring, log='job.log', partition='xenon1t', qos='xenon1t',
+               account='pi-lgrandi', jobname='somejob',
+               delete_file=True, dry_run=False, mem_per_cpu=1000,
+               container='xenonnt-development.simg',
+               cpus_per_task=1):
+
+    os.makedirs(TMPDIR, exist_ok=True)
+
+    if container:
+        # need to wrap job into another executable
+        _, exec_file = tempfile.mkstemp(suffix='.sh')
+        jobstring = singularity_wrap(jobstring, container)
+        jobstring = 'module load singularity\n' + jobstring
+
+    sbatch_script = sbatch_template.format(jobname=jobname, log=log, qos=qos, partition=partition,
+                                           account=account, job=jobstring, mem_per_cpu=mem_per_cpu,
+                                           cpus_per_task=cpus_per_task)
+
+    if dry_run:
+        print("=== DRY RUN ===")
+        print(sbatch_script)
+        return
+
+    _, file = tempfile.mkstemp(suffix='.sbatch')
+    with open(file, 'w') as f:
+        f.write(sbatch_script)
+
+    command = "sbatch %s" % file
+    if not delete_file:
+        print("Executing: %s" % command)
+    subprocess.Popen(shlex.split(command)).communicate()
+
+    if delete_file:
+        os.remove(file)
+
+
+def count_jobs(string=''):
+    username = os.environ.get("USER")
+    output = subprocess.check_output(shlex.split("squeue -u %s" % username))
+    lines = output.decode('utf-8').split('\n')
+    return len([job for job in lines if string in job])
+

--- a/utilix/rundb.py
+++ b/utilix/rundb.py
@@ -124,14 +124,14 @@ class Token:
                 json_in = json.load(f)
                 self.string = json_in['string']
                 self.creation_time = json_in['creation_time']
-                # some old token files might not have the user field
-                if 'user' in json_in:
-                    self.user = json_in['user']
-                # if not, make a new token
-                else:
-                    logger.debug(f'Creating new token')
-                    self.string, self.user = self.new_token()
-                    self.creation_time = datetime.datetime.now().timestamp()
+            # some old token files might not have the user field
+            if 'user' in json_in:
+                self.user = json_in['user']
+            # if not, make a new token
+            else:
+                logger.debug(f'Creating new token')
+                self.string, self.user = self.new_token()
+                self.creation_time = datetime.datetime.now().timestamp()
         else:
             logger.debug(f'Creating new token')
             self.string, self.user = self.new_token()
@@ -181,15 +181,17 @@ class Token:
         headers = BASE_HEADERS.copy()
         headers['Authorization'] = "Bearer {string}".format(string=self.string)
         response = requests.get(url, headers=headers)
+        response = json.loads(response.text)
+
         # if rewew fails, try logging back in
-        if (response.status_code is None or response.status_code is not 200):
-            self.string = self.new_token()
+        if (response['status_code'] is not 200 and response['error'] != 'EarlyRefreshError'):
+            print("Refreshing token")
+            self.string, self.user = self.new_token()
+            print(self.string, self.user)
             self.creation_time = datetime.datetime.now().timestamp()
-        else:
-            self.string = json.loads(response.text)['access_token']
-        # write out again
-        self.write()
-        logger.debug("Token refreshed")
+            self.write()
+            logger.debug("Token refreshed")
+
 
     def write(self):
         with open(self.path, "w") as f:

--- a/utilix/rundb.py
+++ b/utilix/rundb.py
@@ -187,7 +187,6 @@ class Token:
         if (response['status_code'] is not 200 and response['error'] != 'EarlyRefreshError'):
             print("Refreshing token")
             self.string, self.user = self.new_token()
-            print(self.string, self.user)
             self.creation_time = datetime.datetime.now().timestamp()
             self.write()
             logger.debug("Token refreshed")


### PR DESCRIPTION
This includes (1) a bug fix in the Token class where the authentication got messed up and (2) a new module called batchq that can be used for easy job submission to the midway queue. As an example, in a python script you could do:


```
from utilix.batchq import submit_job
job_script = 'python -c import straxen; print(straxen.__version__, straxen.__file__)'
submit_job(job_script)
```

While you don't need to pass them, usually you would want to include more kwargs, e.g.:

```
submit_job(job_script, log='path/to/log', jobname='your_jobname', mem_per_cpu=4000)
```

By default the job will run inside the development base env container, but you can specify to not use container or use a different one with another kwarg. 

