### PR TITLE
Update rundb.py for smooth processing at DAQ

### DIFF
--- a/utilix/rundb.py
+++ b/utilix/rundb.py
@@ -468,8 +468,7 @@ def pymongo_collection(collection='runs', **kwargs):
     if not database:
         database = uconfig.get('RunDB', 'pymongo_database')
     uri = uri.format(user=user, pw=pw, url=url)
-    c = pymongo.MongoClient(uri, readPreference='secondaryPreferred',
-                            serverSelectionTimeoutMS=2000)
+    c = pymongo.MongoClient(uri, readPreference='secondaryPreferred')
     DB = c[database]
     coll = DB[collection]
     # Checkout the collection we are returning and raise errors if you want


### PR DESCRIPTION
This one option is associated to failures on the event-builders. I'm quite puzzled as to why but for now it might be saver to disable such an option.