### PR TITLE
Address timeouts for single mirrors

### DIFF
--- a/utilix/rundb.py
+++ b/utilix/rundb.py
@@ -485,7 +485,12 @@ def pymongo_collection(collection='runs', **kwargs):
     if not database:
         database = uconfig.get('RunDB', 'pymongo_database')
     uri = uri.format(user=user, pw=pw, url=url)
-    c = pymongo.MongoClient(uri, readPreference='secondaryPreferred')
+    if ',' in uri:
+        # Multiple mirrors, may need to specify read preference
+        c = pymongo.MongoClient(uri, readPreference='secondaryPreferred')
+    else:
+        # From a single mirror there is not that much to select
+        c = pymongo.MongoClient(uri)
     DB = c[database]
     coll = DB[collection]
     # Checkout the collection we are returning and raise errors if you want


### PR DESCRIPTION
See https://xenonnt.slack.com/archives/C016UJZ090B/p1608569927016100 for the problem. For a single mirror (e.g. on the ebs) there is no need to provide this argument and it seems that it is causing issues.

**Is this a solution?**
I cannot confirm. I tested it but while doing so, when I reverted this change, the error was gone. It is somewhat anoying if one cannot reproduce the error. Now I don't know if the error just stopped occurring or if this was a fix after all.