### PR TITLE
Different collections for 1T and nT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 utilix.egg-info
 **/__pycache__
-
+.idea
 # pycache
 *.pyc

--- a/utilix/rundb.py
+++ b/utilix/rundb.py
@@ -508,7 +508,7 @@ def pymongo_collection(collection='runs', **kwargs):
 
 def _collection(experiment, collection, **kwargs):
     if experiment not in ['xe1t', 'xent']:
-        raise ValueError("experiment must be '1t' or 'nt'")
+        raise ValueError(f"experiment must be 'xe1t' or 'xent'. You passed f{experiment}")
     uri = 'mongodb://{user}:{pw}@{url}'
     url = kwargs.get('url')
     user = kwargs.get('user')
@@ -516,7 +516,7 @@ def _collection(experiment, collection, **kwargs):
     database = kwargs.get('database')
 
     if not url:
-        url = uconfig.get('RunDB', 'pymongo_url')
+        url = uconfig.get('RunDB', f'{experiment}_url')
     if not user:
         user = uconfig.get('RunDB', f'{experiment}_user')
     if not pw:
@@ -533,8 +533,8 @@ def _collection(experiment, collection, **kwargs):
 
 
 def xent_collection(collection='runs', **kwargs):
-    return _collection('nt', collection, **kwargs)
+    return _collection('xent', collection, **kwargs)
 
 
 def xe1t_collection(collection='runs_new', **kwargs):
-    return _collection('1t', collection, **kwargs)
+    return _collection('xe1t', collection, **kwargs)


### PR DESCRIPTION
This PR implements two different functions for setting up the xenon1t and xenonnt collections respectively. It deprecates the old `pymongo_collection` function in favor of `xe1t_collection` and `xent_collection` functions. 

To use this functionality, you need to modify your xenon_config to have 

```
[RunDB]
xent_url = 
xent_user = 
xent_password =
xent_database = 
xe1t_url =
xe1t_user = 
xe1t_password = 
xe1t_database = 
```

This should make it easier to work with both xenon1t and xenonnt run databases simultaneously without modifying your config file. 