### PR TITLE
Use config option for initializing DB class or not

### DIFF
--- a/utilix/__init__.py
+++ b/utilix/__init__.py
@@ -11,7 +11,7 @@ except FileNotFoundError as e:
          f'access the database. See https://github.com/XENONnT/utilix.')
 
 if uconfig is not None and uconfig.getboolean('utilix', 'initialize_db_on_import',
-                                              fallback=False):
+                                              fallback=True):
     from utilix.rundb import DB
     db = DB()
 else:

--- a/utilix/__init__.py
+++ b/utilix/__init__.py
@@ -5,11 +5,17 @@ from warnings import warn
 try:
     from utilix.config import Config
     uconfig = Config()
-
-    from utilix.rundb import DB
-    db = DB()
 except FileNotFoundError as e:
     uconfig = None
     warn(f'Utilix cannot find config file:\n {e}\nWithout it, you cannot '
          f'access the database. See https://github.com/XENONnT/utilix.')
 
+if uconfig is not None and uconfig.getboolean('utilix', 'initialize_db_on_import',
+                                              fallback=False):
+    from utilix.rundb import DB
+    db = DB()
+else:
+    print("Warning: DB class NOT initialized on import. You cannot do `from utilix import db`")
+    print("If you want to initialize automatically on import, add the following to your utilix config:\n\n"
+          "[utilix]\n"
+          "initialize_db_on_import=true\n")

--- a/utilix/rundb.py
+++ b/utilix/rundb.py
@@ -214,10 +214,11 @@ class Token:
         headers['Authorization'] = f"Bearer {self.token_string}"
         logger.debug(f"Refreshing your token with API call {url}")
         response = requests.get(url, headers=headers)
-        logger.debug(f"The response was {response.text}")
+        response_json = json.loads(response.text)
+        logger.debug(f'The response contains these keys: {list(response_json.keys())}')
         # if renew fails, try logging back in
         if response.status_code != 200:
-            if json.loads(response.text)['error'] != 'EarlyRefreshError':
+            if response_json['error'] != 'EarlyRefreshError':
                 logger.warning("Refreshing token failed for some reason, so making a  new one")
                 self.new_token()
                 self.creation_time = datetime.datetime.now().timestamp()


### PR DESCRIPTION
This addresses #34. It introduces a new config option in the utilix config that looks like this: 

```
[utilix]
initialize_db_on_import = true
```
 
If the field doesn't exist or `initialize_db_on_import=false`, then utilix will not initialize a DB class instance. 

Since I imagine users will most likely want this feature, a warning statement is printed if the DB class is not instantiated: 

```
(XENONnT_development) bash-4.2$ python -c "import utilix"
Warning: DB class NOT initialized on import. You cannot do `from utilix import db`
If you want to initialize automatically on import, add the following to your utilix config:

[utilix]
initialize_db_on_import=true
```
