### PR TITLE
allow import without file

### DIFF
--- a/utilix/__init__.py
+++ b/utilix/__init__.py
@@ -18,6 +18,7 @@ try:
 
 except FileNotFoundError as e:
     uconfig = None
+    logger = None
     warn(f'Utilix cannot find config file:\n {e}\nWithout it, you cannot '
          f'access the database. See https://github.com/XENONnT/utilix.')
 

--- a/utilix/__init__.py
+++ b/utilix/__init__.py
@@ -3,32 +3,28 @@ __version__ = '0.5.0'
 from warnings import warn
 import logging
 
-
-try:
-    from utilix.config import Config
-    uconfig = Config()
-
+def _setup_logger(logging_level):
     logger = logging.getLogger("utilix")
     ch = logging.StreamHandler()
-    ch.setLevel(uconfig.logging_level)
-    logger.setLevel(uconfig.logging_level)
+    ch.setLevel(logging_level)
+    logger.setLevel(logging_level)
     formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
     ch.setFormatter(formatter)
     logger.addHandler(ch)
+    return logger
 
-except FileNotFoundError as e:
-    uconfig = None
-    logger = None
-    warn(f'Utilix cannot find config file:\n {e}\nWithout it, you cannot '
-         f'access the database. See https://github.com/XENONnT/utilix.')
+from utilix.config import Config
+uconfig = Config()
+logger = _setup_logger(uconfig.logging_level)
 
-if uconfig is not None and uconfig.getboolean('utilix', 'initialize_db_on_import',
-                                              fallback=True):
-    from utilix.rundb import DB
-    db = DB()
-else:
-    print("Warning: DB class NOT initialized on import. You cannot do `from utilix import db`")
-    print("If you want to initialize automatically on import, add the following to your utilix config:\n\n"
+if uconfig.config_path is not None:
+    if uconfig.getboolean('utilix', 'initialize_db_on_import', fallback=True):
+        from utilix.rundb import DB
+        db = DB()
+
+    else:
+        print("Warning: DB class NOT initialized on import. You cannot do `from utilix import db`")
+        print("If you want to initialize automatically on import, add the following to your utilix config:\n\n"
           "[utilix]\n"
           "initialize_db_on_import=true\n")
 

--- a/utilix/batchq.py
+++ b/utilix/batchq.py
@@ -18,7 +18,7 @@ sbatch_template = """#!/bin/bash
 """
 
 SINGULARITY_DIR = '/project2/lgrandi/xenonnt/singularity-images'
-TMPDIR = os.path.join(os.environ.get('SCRATCH'), 'tmp')
+TMPDIR = os.path.join(os.environ.get('SCRATCH', '.'), 'tmp')
 
 
 def make_executable(path):

--- a/utilix/rundb.py
+++ b/utilix/rundb.py
@@ -13,7 +13,7 @@ from . import uconfig, io, logger
 # Config the logger:
 
 if uconfig is not None:
-    PREFIX = uconfig.get('RunDB', 'rundb_api_url')
+    PREFIX = uconfig.get('RunDB', 'rundb_api_url', fallback=None)
     BASE_HEADERS = {'Content-Type': "application/json", 'Cache-Control': "no-cache"}
 
 

--- a/utilix/rundb.py
+++ b/utilix/rundb.py
@@ -12,8 +12,9 @@ from . import uconfig, io, logger
 
 # Config the logger:
 
-PREFIX = uconfig.get('RunDB', 'rundb_api_url')
-BASE_HEADERS = {'Content-Type': "application/json", 'Cache-Control': "no-cache"}
+if uconfig is not None:
+    PREFIX = uconfig.get('RunDB', 'rundb_api_url')
+    BASE_HEADERS = {'Content-Type': "application/json", 'Cache-Control': "no-cache"}
 
 
 class NewTokenError(Exception):


### PR DESCRIPTION
Slight tweak to recent PRs, without utilix config file, it would still be nice if `import utilix` doesn't fail. 

**Can you give an example**
```bash
python -c "import utilix"
```

See:
https://github.com/XENONnT/straxen/pull/436/checks?check_run_id=2327495931

Perhaps we should write a test for these sorts of things.