### PR TITLE
Refactor the DB class into DBapi and DBmongo

### DIFF
--- a/utilix/__init__.py
+++ b/utilix/__init__.py
@@ -8,18 +8,14 @@ uconfig = config.Config()
 
 if uconfig.is_configured:
     logger = config.setup_logger(uconfig.logging_level)
-
 else:
     uconfig = None
     logger = config.setup_logger()
 
-from .rundb import xent_collection, xe1t_collection, DBapi, DBmongo
+from .rundb import xent_collection, xe1t_collection, DBapi, DBmongo, get_db
 from .mongo_files import MongoUploader, MongoDownloader, APIUploader, APIDownloader
 from .rundoc_data import RunDocUpload, upload_doc_from_file
 
 # initialize runDB instance if we can
-if uconfig:
-    if uconfig.get('RunDB', 'api_or_mongo', fallback='api') == 'api':
-        db = DBapi()
-    else:
-        db = DBmongo()
+if uconfig and uconfig.get('utilix', 'initialize_db_on_import', fallback=False):
+    db = get_db(use=uconfig.get('utilix', 'default_db', fallback='mongo'))

--- a/utilix/__init__.py
+++ b/utilix/__init__.py
@@ -13,6 +13,13 @@ else:
     uconfig = None
     logger = config.setup_logger()
 
-from .rundb import DB, xent_collection, xe1t_collection
+from .rundb import xent_collection, xe1t_collection, DBapi, DBmongo
 from .mongo_files import MongoUploader, MongoDownloader, APIUploader, APIDownloader
 from .rundoc_data import RunDocUpload, upload_doc_from_file
+
+# initialize runDB instance if we can
+if uconfig:
+    if uconfig.get('RunDB', 'api_or_mongo', fallback='api') == 'api':
+        db = DBapi()
+    else:
+        db = DBmongo()

--- a/utilix/mongo_files.py
+++ b/utilix/mongo_files.py
@@ -29,7 +29,7 @@ import numpy as np
 import pandas as pd
 
 from . import uconfig, logger
-from .rundb import xent_collection, DB
+from .rundb import xent_collection, DBapi
 
 
 class GridFsBase:
@@ -447,7 +447,7 @@ class GridFsInterfaceAPI(GridFsBase):
     def __init__(self, config_identifier='config_name'):
         super().__init__(config_identifier=config_identifier)
         # all the credentials logic is handled by the utilix config, so don't need lengthy setup
-        self.db = DB()
+        self.db = DBapi()
 
     def config_exists(self, config):
         """


### PR DESCRIPTION
This PR aims to improve how the rundb module of utilix is used. In the past we had the `DB` class which was a client to the runDB API, and then we just had a simple function to initialize mongo collections if anyone wanted to do direct pymongo calls. 

In this update, we refactor that `DB` class into 2 subclasses: `DBapi` and `DBmongo`. The primary motivation of this is to standardize how we modify the 'data' field of the runs DB using the methods `update_data` and `delete_data`, but at the same time it also adds convenience wrappers to many database calls used during analysis and production. 

A new utilix config field is also introduced, with header `utilix`, where users can specify which type of DB class they want to use (defaults to mongo) and also whether or not the db should be initialized on import. By default, no initialization occurs, so CI testing should be safe (though tagging @JoranAngevaare in case I missed something).