### PR TITLE
Set max wall time of a job

### DIFF
--- a/utilix/batchq.py
+++ b/utilix/batchq.py
@@ -127,7 +127,7 @@ def submit_job(jobstring,
     subprocess.Popen(shlex.split(command)).communicate()
 
     if remove_file:
-        os.remove(sbatch_script)
+        os.remove(sbatch_file)
 
 
 def count_jobs(string=''):

--- a/utilix/batchq.py
+++ b/utilix/batchq.py
@@ -14,6 +14,7 @@ sbatch_template = """#!/bin/bash
 #SBATCH --partition={partition}
 #SBATCH --mem-per-cpu={mem_per_cpu}
 #SBATCH --cpus-per-task={cpus_per_task}
+#SBATCH --time={hours}
 
 {job}
 """
@@ -58,6 +59,7 @@ def submit_job(jobstring,
                container='xenonnt-development.simg',
                bind=('/dali', '/project2', os.path.dirname(TMPDIR)),
                cpus_per_task=1,
+               hours=24,
                **kwargs
                ):
     """
@@ -86,6 +88,7 @@ def submit_job(jobstring,
     :param container: name of the container to activate
     :param bind: which paths to add to the container
     :param cpus_per_task: cpus requested for job
+    :param hours: max hours of a job
     :param kwargs: are ignored
     :return: None
     """
@@ -99,9 +102,10 @@ def submit_job(jobstring,
         jobstring = singularity_wrap(jobstring, container, bind)
         jobstring = 'unset X509_CERT_DIR\n' + 'module load singularity\n' + jobstring
 
+    hours = '{:02d}:{:02d}:{:02d}'.format(int(hours), int(hours * 60 % 60), int(hours * 60 % 60 * 60 % 60))
     sbatch_script = sbatch_template.format(jobname=jobname, log=log, qos=qos, partition=partition,
                                            account=account, job=jobstring, mem_per_cpu=mem_per_cpu,
-                                           cpus_per_task=cpus_per_task)
+                                           cpus_per_task=cpus_per_task, hours=hours)
 
     if dry_run:
         print("=== DRY RUN ===")

--- a/utilix/batchq.py
+++ b/utilix/batchq.py
@@ -14,7 +14,7 @@ sbatch_template = """#!/bin/bash
 #SBATCH --partition={partition}
 #SBATCH --mem-per-cpu={mem_per_cpu}
 #SBATCH --cpus-per-task={cpus_per_task}
-#SBATCH --time={hours}
+{hours}
 
 {job}
 """
@@ -59,7 +59,7 @@ def submit_job(jobstring,
                container='xenonnt-development.simg',
                bind=('/dali', '/project2', os.path.dirname(TMPDIR)),
                cpus_per_task=1,
-               hours=24,
+               hours=None,
                **kwargs
                ):
     """
@@ -102,7 +102,10 @@ def submit_job(jobstring,
         jobstring = singularity_wrap(jobstring, container, bind)
         jobstring = 'unset X509_CERT_DIR\n' + 'module load singularity\n' + jobstring
 
-    hours = '{:02d}:{:02d}:{:02d}'.format(int(hours), int(hours * 60 % 60), int(hours * 60 % 60 * 60 % 60))
+    if not hours is None:
+        hours = '#SBATCH --time={:02d}:{:02d}:{:02d}'.format(int(hours), int(hours * 60 % 60), int(hours * 60 % 60 * 60 % 60))
+    else:
+        hours = ''
     sbatch_script = sbatch_template.format(jobname=jobname, log=log, qos=qos, partition=partition,
                                            account=account, job=jobstring, mem_per_cpu=mem_per_cpu,
                                            cpus_per_task=cpus_per_task, hours=hours)


### PR DESCRIPTION
Use `--time` in the `.sbatch` script to limit the time a job use. 
The default max job time is set to be 24hr which is suitable for most jobs. 

Additionally, solve a bug when removing the temporary `.sbatch` file. 