### PR TITLE
Add CUTAX_LOCATION to unset list

### DIFF
--- a/utilix/batchq.py
+++ b/utilix/batchq.py
@@ -100,7 +100,7 @@ def submit_job(jobstring,
         # need to wrap job into another executable
         _, exec_file = tempfile.mkstemp(suffix='.sh')
         jobstring = singularity_wrap(jobstring, container, bind)
-        jobstring = 'unset X509_CERT_DIR\n' + 'module load singularity\n' + jobstring
+        jobstring = 'unset X509_CERT_DIR CUTAX_LOCATION\n' + 'module load singularity\n' + jobstring
 
     if not hours is None:
         hours = '#SBATCH --time={:02d}:{:02d}:{:02d}'.format(int(hours), int(hours * 60 % 60), int(hours * 60 % 60 * 60 % 60))


### PR DESCRIPTION
When submitting jobs to midway's batch queue, some env variables get passed to the job. This includes CUTAX_LOCATION, which is what is used to pass a particular cutax version/path. This leads  to unexpected results if, e.g., someone submits a job specifying a container (say `2022.02.4`) from inside a different cvmfs env (say `development`). This PR should fix that issue.