### PR TITLE
Use uconfig for api config management

### DIFF
--- a/utilix/processing_requests.py
+++ b/utilix/processing_requests.py
@@ -27,7 +27,7 @@ RSE = Literal['SURFSARA_USERDISK',
 
 
 def xeauth_user():
-    return uconfig.get('cmt2', 'api_user', fallback='UNKNOWN')
+    return uconfig.get('cmt2', 'api_user', fallback='unknown')
 
 
 def get_envs():
@@ -109,6 +109,8 @@ def xeauth_login(readonly=True):
             xetoken = xeauth.user_login(username,
                                         password,
                                         scopes=scopes)
+
+        uconfig.set('cmt2', 'api_user', xetoken.username)
         
         return xetoken.access_token
     except: 

--- a/utilix/processing_requests.py
+++ b/utilix/processing_requests.py
@@ -74,6 +74,16 @@ class ProcessingRequest(rframe.BaseSchema):
     def default_datasource(cls):
         return processing_api()
 
+    def latest_context(self):
+        import utilix
+        import pymongo
+
+        contexts = utilix.xent_collection('contexts')
+        ctx = contexts.find_one({f'hashes.{self.data_type}': self.lineage_hash},
+                  projection={'name': 1,'tag': 1, '_id': 0},
+                  sort=[('date_added', pymongo.DESCENDING)])
+        return ctx
+
 
 class ProcessingJob(rframe.BaseSchema):
     _NAME = 'processing_jobs'
@@ -99,7 +109,7 @@ def xeauth_login(readonly=True):
         scopes = ['read:all'] if readonly else ['read:all', 'write:all']
         audience = uconfig.get('cmt2', 'api_audience', fallback='https://api.cmt.xenonnt.org')
 
-        username = uconfig.get('cmt2', 'api_user', fallback='UNKNOWN')
+        username = uconfig.get('cmt2', 'api_user', fallback='unknown')
             
         password = uconfig.get('cmt2', 'api_password', fallback=None)
 

--- a/utilix/processing_requests.py
+++ b/utilix/processing_requests.py
@@ -13,7 +13,10 @@ import utilix
 
 CACHE = {}
 DEFAULT_ENV = '2022.03.5'
+ENV_PATH = "/cvmfs/singularity.opensciencegrid.org/xenonnt/base-environment:{tag}"
+
 ENV_TAGS_URL = 'https://api.github.com/repos/xenonnt/base_environment/git/matching-refs/tags/'
+
 
 API_URL = 'https://api.xedocs.yossisprojects.com'
 
@@ -113,10 +116,12 @@ class ProcessingJob(rframe.BaseSchema):
 
     def create_workflow(self, **kwargs):
         from outsource.Outsource import Outsource
-
-        wf = Outsource([self.run_id], 
-                    context=self.context, 
-                    image=self.env,
+        
+        image = ENV_PATH.format(tag=self.env)
+        wf = Outsource([int(self.run_id)], 
+                    context_name=self.context, 
+                    image=image,
+                    wf_id=str(self.job_id),
                     **kwargs)
         return wf
 

--- a/utilix/processing_requests.py
+++ b/utilix/processing_requests.py
@@ -6,8 +6,9 @@ import datetime
 import getpass
 import pydantic
 import requests
+from itertools import product
 from warnings import warn
-from . import uconfig
+import utilix
 
 CACHE = {}
 DEFAULT_ENV = '2022.03.5'
@@ -15,8 +16,8 @@ ENV_TAGS_URL = 'https://api.github.com/repos/xenonnt/base_environment/git/matchi
 
 API_URL = 'https://api.xedocs.yossisprojects.com'
 
-if uconfig is not None:
-    API_URL = uconfig.get('cmt2', 'api_url', fallback=API_URL)
+if utilix.uconfig is not None:
+    API_URL = utilix.uconfig.get('cmt2', 'api_url', fallback=API_URL)
 
 
 RSE_TYPE = Literal['SURFSARA_USERDISK',
@@ -28,7 +29,7 @@ RSE_TYPE = Literal['SURFSARA_USERDISK',
 
 
 def xeauth_user():
-    return uconfig.get('cmt2', 'api_user', fallback='unknown')
+    return utilix.uconfig.get('cmt2', 'api_user', fallback='unknown')
 
 
 def get_envs():
@@ -83,18 +84,19 @@ class ProcessingRequest(rframe.BaseSchema):
         ctx = contexts.find_one({f'hashes.{self.data_type}': self.lineage_hash},
                   projection={'name': 1, 'env': '$tag', '_id': 0},
                   sort=[('date_added', pymongo.DESCENDING)])
-        return ctx
+        return dict(ctx)
 
     def create_job(self):
         kwargs = self.latest_context()
         kwargs.update(self.dict())
+        kwargs['job_id'] = uuid.uuid4()
         return ProcessingJob(**kwargs)
 
 
 class ProcessingJob(rframe.BaseSchema):
     _ALIAS = 'processing_jobs'
 
-    job_id: uuid.UUID = rframe.Index(default_factory=uuid.uuid4)
+    job_id: uuid.UUID = rframe.Index()
     destination: RSE_TYPE = rframe.Index()
     env: str = rframe.Index()
     context: str = rframe.Index()
@@ -118,28 +120,32 @@ class ProcessingJob(rframe.BaseSchema):
 def xeauth_login(readonly=True):
     try:
         import xeauth
-        scopes = ['read:all'] if readonly else ['read:all', 'write:all']
-        audience = uconfig.get('cmt2', 'api_audience', fallback='https://api.cmt.xenonnt.org')
+        scopes = ['openid', 'profile', 'email', 'offline_access', 'read:all']
+        if not readonly:
+            scopes.append('write:all')
+        audience = utilix.uconfig.get('cmt2', 'api_audience', 
+                                            fallback='https://api.cmt.xenonnt.org')
 
-        username = uconfig.get('cmt2', 'api_user', fallback='unknown')
-            
-        password = uconfig.get('cmt2', 'api_password', fallback=None)
+        username = utilix.uconfig.get('cmt2', 'api_user', fallback=None)
+        password = utilix.uconfig.get('cmt2', 'api_password', fallback=None)
 
-        if password is None:
+        if username is None or password is None:
             xetoken = xeauth.login(scopes=scopes, audience=audience)
+            utilix.uconfig.set('cmt2', 'api_user', xetoken.username)
+            
         else:
             xetoken = xeauth.user_login(username,
                                         password,
                                         scopes=scopes)
-
-        uconfig.set('cmt2', 'api_user', xetoken.username)
-        
         return xetoken.access_token
     except: 
         return None
 
 
 def valid_token(token, readonly=True):
+    if not token:
+        return False
+
     if readonly:
         scope = 'read:all'
     else:
@@ -157,7 +163,7 @@ def valid_token(token, readonly=True):
 def processing_api(token=None, readonly=False):
 
     if token is None:
-        token = uconfig.get('cmt2', 'api_token', fallback=None)
+        token = utilix.uconfig.get('cmt2', 'api_token', fallback=None)
 
     if not valid_token(token, readonly=readonly):
         token = None
@@ -171,7 +177,7 @@ def processing_api(token=None, readonly=False):
     headers = {}
     if token:
         headers['Authorization'] = f"Bearer {token}"
-        token = uconfig.set('cmt2', 'api_token', token)
+        utilix.uconfig.set('cmt2', 'api_token', token)
 
     client = rframe.RestClient(f'{API_URL}/processing_requests',
                                  headers=headers,)
@@ -182,24 +188,29 @@ try:
     import tqdm
 
     @strax.Context.add_method
-    def request_processing(context, run_ids, data_type,
+    def request_processing(context, 
+                           run_ids, 
+                           data_types,
                            priority=-1, comments='',
                            destination='UC_DALI_USERDISK',
                            token=None, submit=True):
         client = processing_api(token=token, readonly=False)
 
         run_ids = strax.to_str_tuple(run_ids)
+        data_types = strax.to_str_tuple(data_types)
+        
+        combinations = product(run_ids, data_types)
+
         requests = []
-        for run_id in tqdm.tqdm(run_ids, desc='Requesting processing'):
-            
+        for run_id, data_type in tqdm.tqdm(combinations, desc='Requesting processing'):
             lineage_hash = context.key_for(run_id, data_type).lineage_hash
 
             kwargs = dict(data_type=data_type, 
-                          lineage_hash=lineage_hash,
-                          run_id=run_id,
-                          priority=priority,
-                          destination=destination,
-                          comments=comments)
+                        lineage_hash=lineage_hash,
+                        run_id=run_id,
+                        priority=priority,
+                        destination=destination,
+                        comments=comments)
             
             request = ProcessingRequest(**kwargs)
             requests.append(request)

--- a/utilix/processing_requests.py
+++ b/utilix/processing_requests.py
@@ -139,7 +139,7 @@ try:
     @strax.Context.add_method
     def request_processing(context, run_ids, data_type,
                            priority=-1, comments='',
-                           destination='DALI',
+                           destination='UC_DALI_USERDISK',
                            token=None, submit=True):
         client = processing_api(token=token, readonly=False)
 


### PR DESCRIPTION
Just realised that Evans comment about using uconfig is also relevant to some other values i read from env variables or hardcoded.
Now use uconfig for:
 - api url
 - api token/username and password
 - API audience

Also adding some helpers that will be useful for automating job submission