### PR TITLE
Added keyword function to specify which node a job should run on

### DIFF
--- a/utilix/batchq.py
+++ b/utilix/batchq.py
@@ -110,11 +110,16 @@ def submit_job(jobstring,
         hours = ''
 
     if not node is None:
+        if not isinstance(node, str):
+            raise ValueError(f'node should be str but given {type(node)}')
         node = '#SBATCH --nodelist={node}'.format(node=node)
     else:
         node = ''
 
     if not exclude_nodes is None:
+        if not isinstance(node, str):
+            raise ValueError(f'exclude_nodes should be str but given {type(exclude_nodes)}')
+            # string like 'myCluster01,myCluster02,myCluster03' or 'myCluster[01-09]'
         exclude_nodes = '#SBATCH --exclude={exclude_nodes}'.format(exclude_nodes=exclude_nodes)
     else:
         exclude_nodes = ''

--- a/utilix/batchq.py
+++ b/utilix/batchq.py
@@ -15,6 +15,7 @@ sbatch_template = """#!/bin/bash
 #SBATCH --mem-per-cpu={mem_per_cpu}
 #SBATCH --cpus-per-task={cpus_per_task}
 {node}
+{exclude_nodes}
 {hours}
 
 {job}
@@ -59,6 +60,7 @@ def submit_job(jobstring,
                cpus_per_task=1,
                hours=None,
                node=None,
+               exclude_nodes=None,
                **kwargs
                ):
     """
@@ -88,7 +90,8 @@ def submit_job(jobstring,
     :param bind: which paths to add to the container
     :param cpus_per_task: cpus requested for job
     :param hours: max hours of a job
-    :param node: define a certain node to submit your job should be submitted to 
+    :param node: define a certain node to submit your job should be submitted to
+    :param exclude_nodes: define a list of nodes which should be excluded from submission
     :param kwargs: are ignored
     :return: None
     """
@@ -111,9 +114,15 @@ def submit_job(jobstring,
     else:
         node = ''
 
+    if not exclude_nodes is None:
+        exclude_nodes = '#SBATCH --exclude={exclude_nodes}'.format(exclude_nodes=exclude_nodes)
+    else:
+        exclude_nodes = ''
+
     sbatch_script = sbatch_template.format(jobname=jobname, log=log, qos=qos, partition=partition,
                                            account=account, job=jobstring, mem_per_cpu=mem_per_cpu,
-                                           cpus_per_task=cpus_per_task, hours=hours, node=node)
+                                           cpus_per_task=cpus_per_task, hours=hours, node=node,
+                                           exclude_nodes=exclude_nodes)
 
     if dry_run:
         print("=== DRY RUN ===")

--- a/utilix/batchq.py
+++ b/utilix/batchq.py
@@ -14,6 +14,7 @@ sbatch_template = """#!/bin/bash
 #SBATCH --partition={partition}
 #SBATCH --mem-per-cpu={mem_per_cpu}
 #SBATCH --cpus-per-task={cpus_per_task}
+{node}
 {hours}
 
 {job}
@@ -57,6 +58,7 @@ def submit_job(jobstring,
                bind=('/dali', '/project2', os.path.dirname(TMPDIR)),
                cpus_per_task=1,
                hours=None,
+               node=None,
                **kwargs
                ):
     """
@@ -86,6 +88,7 @@ def submit_job(jobstring,
     :param bind: which paths to add to the container
     :param cpus_per_task: cpus requested for job
     :param hours: max hours of a job
+    :param node: define a certain node to submit your job should be submitted to 
     :param kwargs: are ignored
     :return: None
     """
@@ -102,9 +105,15 @@ def submit_job(jobstring,
         hours = '#SBATCH --time={:02d}:{:02d}:{:02d}'.format(int(hours), int(hours * 60 % 60), int(hours * 60 % 60 * 60 % 60))
     else:
         hours = ''
+
+    if not node is None:
+        node = '#SBATCH --nodelist={node}'.format(node=node)
+    else:
+        node = ''
+
     sbatch_script = sbatch_template.format(jobname=jobname, log=log, qos=qos, partition=partition,
                                            account=account, job=jobstring, mem_per_cpu=mem_per_cpu,
-                                           cpus_per_task=cpus_per_task, hours=hours)
+                                           cpus_per_task=cpus_per_task, hours=hours, node=node)
 
     if dry_run:
         print("=== DRY RUN ===")

--- a/utilix/batchq.py
+++ b/utilix/batchq.py
@@ -117,7 +117,7 @@ def submit_job(jobstring,
         node = ''
 
     if not exclude_nodes is None:
-        if not isinstance(node, str):
+        if not isinstance(exclude_nodes, str):
             raise ValueError(f'exclude_nodes should be str but given {type(exclude_nodes)}')
             # string like 'myCluster01,myCluster02,myCluster03' or 'myCluster[01-09]'
         exclude_nodes = '#SBATCH --exclude={exclude_nodes}'.format(exclude_nodes=exclude_nodes)


### PR DESCRIPTION
This PR adds the keyword `node` into the submission function.
With which the user is able to select onto which node their job should be submitted to.
Also the keyword `exclusion_list` ist added, which allows to define a list of nodes that should not be used for submission.