### PR TITLE
Return job id and allow for dependencies

### DIFF
--- a/utilix/batchq.py
+++ b/utilix/batchq.py
@@ -231,8 +231,6 @@ def submit_job(jobstring,
     if process.returncode == 0:
         # Extract the job ID from the output
         job_id = output.decode().strip().split()[-1]
-        # Store the job ID in the list
-        submitted_jobs.append(job_id)
     else:
         job_id = None
         # Handle the case where the job submission failed

--- a/utilix/batchq.py
+++ b/utilix/batchq.py
@@ -192,7 +192,7 @@ def submit_job(jobstring,
 
     if not dependency is None:
         job_ids = ":".join(dependency)
-        dependency = " --dependency=afterok:"+job_ids
+        dependency = "--dependency=afterok:"+job_ids
         print(dependency)
     else:
         dependency = ''

--- a/utilix/batchq.py
+++ b/utilix/batchq.py
@@ -219,7 +219,7 @@ def submit_job(jobstring,
         f.write(sbatch_script)
 
 
-    command = "sbatch%s %s" % (dependency, sbatch_file)
+    command = "sbatch %s %s" % (dependency, sbatch_file)
     if not sbatch_file:
         print("Executing: %s" % command)
 

--- a/utilix/batchq.py
+++ b/utilix/batchq.py
@@ -196,8 +196,17 @@ def submit_job(jobstring,
         exclude_nodes = ''
 
     if not dependency is None:
-        job_ids = ":".join(dependency)
+        if isinstance(dependency, list):
+            # Handle list of strings
+            job_ids = ":".join(dependency)
+        elif isinstance(dependency, str):
+            # Handle single string
+            job_ids = dependency
+        else:
+            raise ValueError(f'dependency should be list or str but given {type(dependency)}')
+        
         dependency = "--dependency=afterok:"+job_ids+" --kill-on-invalid-dep=yes"
+    
     else:
         dependency = ''
 


### PR DESCRIPTION
With this PR I would like to introduce the possibility to have dependencies on jobs using the batchq.submit_job function.

Now the function returns the job_id if the job submission succeeded, so that a user can use a script to submit jobs, get the ids of the submitted jobs, and submit a secondary job that will start only when the initial jobs will complete with exit code 0. 

Example script to use the new functionality: 



```
submitted_jobs = []
for i in range(5):
    job_id = batchq.submit_job(jobstring, 
                      jobname=jobname, 
                      partition='dali', 
                      )
    
    submitted_jobs.append(job_id)


if not None in submitted_jobs:

    job_id = batchq.submit_job(jobstring, 
                               jobname='afterok', 
                               partition='dali',
                               dependency=submitted_jobs)


```


.
.
.

See slurm sbatch [documentation](https://slurm.schedmd.com/sbatch.html):

-d, --dependency=<dependency_list>
Defer the start of this job until the specified dependencies have been satisfied completed. <dependency_list> is of the form <type:job_id[:job_id][,type:job_id[:job_id]]> or <type:job_id[:job_id][?type:job_id[:job_id]]>. All dependencies must be satisfied if the "," separator is used. Any dependency may be satisfied if the "?" separator is used. Only one separator may be used. For instance:
-d afterok:20:21,afterany:23
means that the job can run only after a 0 return code of jobs 20 and 21 AND the completion of job 23. However:
-d afterok:20:21?afterany:23
means that any of the conditions (afterok:20 OR afterok:21 OR afterany:23) will be enough to release the job. Many jobs can share the same dependency and these jobs may even belong to different users. The value may be changed after job submission using the scontrol command. Dependencies on remote jobs are allowed in a federation. Once a job dependency fails due to the termination state of a preceding job, the dependent job will never be run, even if the preceding job is requeued and has a different termination state in a subsequent execution.

afterok:job_id[:jobid...]
This job can begin execution after the specified jobs have successfully executed (ran to completion with an exit code of zero).



