### PR TITLE
Completely refactor batchq using simple_slurm and pydantic

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ The script will open a web-browser if possible, and also print out the URL you n
 
 ## Batch queue submission
 
-### Class `JobSubmission`
+### Class `JobSubmission` (Since v0.8.0)
 
 The JobSubmission class is designed to simplify the process of creating and submitting jobs to a computational cluster. This class encapsulates all the necessary details required to submit a job, such as the command to execute, job logging, partition selection, and resource allocation. It's built to be flexible and easy to use, catering to a variety of job submission needs.
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,73 @@ Example:
 The script will open a web-browser if possible, and also print out the URL you need to visit to authorize the script to operate on your behalf. After you login using github and authorize the request, the script will get a token and save it in memory for the next requests.
 
 
+## Batch queue submission
 
+### Class `JobSubmission`
+
+The JobSubmission class is designed to simplify the process of creating and submitting jobs to a computational cluster. This class encapsulates all the necessary details required to submit a job, such as the command to execute, job logging, partition selection, and resource allocation. It's built to be flexible and easy to use, catering to a variety of job submission needs.
+
+- `jobstring`: The command that will be executed by the job. It is mandatory.
+- `log`: The filepath where the job's log file will be stored. Default is "job.log".
+- `partition`: Specifies the partition to submit the job to. Supported partitions are dali, lgrandi, xenon1t, broadwl, kicp, caslake. Default is xenon1t.
+- `qos`: Quality of Service to submit the job to. Default is xenon1t.
+- `account`: The account under which the job is submitted. Default is pi-lgrandi.
+- `jobname`: The name of the job. Default is somejob.
+- `sbatch_file`: Deprecated.
+- `dry_run`: If set to True, the job submission will only be simulated. Default is False.
+- `mem_per_cpu`: Memory (in MB) requested per CPU. Default is 1000MB.
+- `container`: The name of the container to activate for this job. Default is xenonnt-development.simg.
+- `bind`: A list of paths to add to the container. It's immutable for the dali partition.
+- `cpus_per_task`: Number of CPUs requested for the job. Default is 1.
+- `hours`: Maximum duration of the job in hours. Optional.
+- `node`: Specific node to submit your job to. Optional.
+- `exclude_nodes`: List of nodes to be excluded from submission. Optional.
+- `dependency`: List of job IDs that must complete before this job begins. Optional.
+- `verbose`: If True, prints the sbatch command before submitting. Default is False.
+
+```python
+from utilix.batchq import JobSubmission
+
+job = JobSubmission(
+    jobstring="python my_script.py --run_list 123456 234567",
+    log="my_job.log",
+    partition="xenon1t",
+    qos="xenon1t",
+    jobname="my_analysis_job",
+    dry_run=False,
+    mem_per_cpu=2000,
+    container="xenonnt-2024.01.1.simg",
+    cpus_per_task=4,
+    hours=12,
+    verbose=True
+)
+
+job.submit()
+```
+
+### Method `submit_job` (Legacy)
+
+If you have a script written with `utilix<0.8.0`, you probably used the `submit_job` method. This method is now deprecated but still available for backward compatibility. It's recommended to use the `JobSubmission` class instead.
+
+The example below is equivalent to the previous one:
+
+```python
+from utilix.batchq import submit_job
+
+submit_job(
+    jobstring="python my_script.py --run_list 123456 234567",
+    log="my_job.log",
+    partition="xenon1t",
+    qos="xenon1t",
+    jobname="my_analysis_job",
+    dry_run=False,
+    mem_per_cpu=2000,
+    container="xenonnt-2024.01.1.simg",
+    cpus_per_task=4,
+    hours=12,
+    verbose=True
+)
+```
 
 
 ## TODO

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ requests
 tqdm
 pandas
 commentjson
+simiple_slurm
+pydantic

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ requests
 tqdm
 pandas
 commentjson
-simiple_slurm
+simple_slurm
 pydantic

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open('HISTORY.md') as file:
 
 setup(
     name="utilix",
-    version="0.7.7",
+    version="0.8.0",
     url='https://github.com/XENONnT/utilix',
     description="User-friendly interface to various utilities for XENON users",
     long_description_content_type='text/markdown',

--- a/utilix/__init__.py
+++ b/utilix/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.7.7'
+__version__ = "0.8.0"
 
 from . import config
 

--- a/utilix/batchq.py
+++ b/utilix/batchq.py
@@ -241,6 +241,7 @@ class JobSubmission(BaseModel):
             self.jobstring = self.__singularity_wrap(
                 self.jobstring, self.container, self.bind, self.partition
             )
+        print(f"No container specified, running job as is")
 
         # Add the job command
         slurm.add_cmd(self.jobstring)

--- a/utilix/batchq.py
+++ b/utilix/batchq.py
@@ -185,7 +185,6 @@ class JobSubmission(BaseModel):
 
     def __init__(self, **data):
         super().__init__(**data)
-        os.makedirs(TMPDIR[self.partition], exist_ok=True)
 
     def _create_singularity_jobstring(self) -> str:
         """
@@ -233,6 +232,7 @@ class JobSubmission(BaseModel):
         """
         Submit the job to the SLURM queue.
         """
+        os.makedirs(TMPDIR[self.partition], exist_ok=True)
         # Initialize a dictionary with mandatory parameters
         slurm_kwargs = {
             "job_name": self.jobname,

--- a/utilix/batchq.py
+++ b/utilix/batchq.py
@@ -167,13 +167,14 @@ class JobSubmission(BaseModel):
         return v
 
     @validator("container")
-    def check_container_format(cls, v) -> str:
+    def check_container_format(cls, v, values) -> str:
         if not v.endswith(".simg"):
             raise ValueError("Container must end with .simg")
         # Check if the container exists
-        if not os.path.exists(os.path.join(SINGULARITY_DIR[cls.partition], v)):
+        partition = values.get("partition")
+        if not os.path.exists(os.path.join(SINGULARITY_DIR[partition], v)):
             raise FileNotFoundError(
-                f"Singularity image {v} does not exist in {SINGULARITY_DIR[cls.partition]}"
+                f"Singularity image {v} does not exist in {SINGULARITY_DIR[partition]}"
             )
         return v
 

--- a/utilix/batchq.py
+++ b/utilix/batchq.py
@@ -187,7 +187,7 @@ class JobSubmission(BaseModel):
         super().__init__(**data)
         os.makedirs(TMPDIR[self.partition], exist_ok=True)
 
-    def __singularity_wrap(self) -> str:
+    def _create_singularity_jobstring(self) -> str:
         """
         Wrap the jobstring with the singularity command.
 
@@ -261,7 +261,7 @@ class JobSubmission(BaseModel):
 
         # Process the jobstring with the container if specified
         if self.container is not None:
-            self.jobstring = self.__singularity_wrap()
+            self.jobstring = self._create_singularity_jobstring()
         elif self.verbose:
             print(f"No container specified, running job as is")
 

--- a/utilix/batchq.py
+++ b/utilix/batchq.py
@@ -260,7 +260,7 @@ class JobSubmission(BaseModel):
         slurm.sbatch()
 
 
-def submit_job(**kwargs):
+def submit_job(*args, **kwargs):
     """
     Adapter to old function name.
     You should use JobSubmission to get modern code editor support.
@@ -271,7 +271,7 @@ def submit_job(**kwargs):
     logger.warning(
         "Using legacy function name, please use JobSubmission to get modern code editor support"
     )
-    job = JobSubmission(**kwargs)
+    job = JobSubmission(*args, **kwargs)
     job.submit()
 
 

--- a/utilix/batchq.py
+++ b/utilix/batchq.py
@@ -248,7 +248,7 @@ class JobSubmission(BaseModel):
         print(f"Your log is located at: {self.log}")
 
         # Handle dry run scenario
-        print(f"Generated slurm script:\n{slurm.script}")
+        print(f"Generated slurm script:\n{slurm.script()}")
         if self.dry_run:
             return
         # Submit the job

--- a/utilix/batchq.py
+++ b/utilix/batchq.py
@@ -239,9 +239,7 @@ class JobSubmission(BaseModel):
 
         # Process the jobstring with the container if specified
         if self.container is not None:
-            self.jobstring = self.__singularity_wrap(
-                self.jobstring, self.container, self.bind, self.partition
-            )
+            self.jobstring = self.__singularity_wrap()
         print(f"No container specified, running job as is")
 
         # Add the job command

--- a/utilix/batchq.py
+++ b/utilix/batchq.py
@@ -1,265 +1,261 @@
-import subprocess
+import datetime
 import os
+import subprocess
+import re
 import tempfile
-import shlex
+from typing import Literal
+from pydantic import BaseModel, Field, validator
+from simple_slurm import Slurm
 from utilix import logger
-import getpass
 
-sbatch_template = """#!/bin/bash
-
-#SBATCH --job-name={jobname}
-#SBATCH --output={log}
-#SBATCH --error={log}
-#SBATCH --account=pi-lgrandi
-#SBATCH --qos={qos}
-#SBATCH --partition={partition}
-#SBATCH --mem-per-cpu={mem_per_cpu}
-#SBATCH --cpus-per-task={cpus_per_task}
-{node}
-{exclude_nodes}
-{hours}
-
-{job}
-"""
-
-SINGULARITY_DIR = {
-    'dali': '/dali/lgrandi/xenonnt/singularity-images',
-    'lgrandi': '/project2/lgrandi/xenonnt/singularity-images',
-    'xenon1t': '/project2/lgrandi/xenonnt/singularity-images',
-    'broadwl': '/project2/lgrandi/xenonnt/singularity-images',
-    'kicp': '/project2/lgrandi/xenonnt/singularity-images',
-    'caslake': '/project2/lgrandi/xenonnt/singularity-images',
-}
-
-SCRATCH_DIR = os.environ.get('SCRATCH')
-if len(SCRATCH_DIR.split('/'))==3 and SCRATCH_DIR.split('/')[-1]=='midway3':
-    SCRATCH_DIR += '/%s'%(os.environ['USER'])
-
+USER = os.environ.get("USER")
+SCRATCH_DIR = os.environ.get("SCRATCH", ".")
+PARTITIONS = ["dali", "lgrandi", "xenon1t", "broadwl", "kicp", "caslake"]
 TMPDIR = {
-    'dali': os.path.expanduser('/dali/lgrandi/%s/tmp'%(getpass.getuser())),
-    'lgrandi': os.path.join(SCRATCH_DIR, 'tmp'),
-    'xenon1t': os.path.join(os.environ.get('SCRATCH', '.'), 'tmp'),
-    'broadwl': os.path.join(os.environ.get('SCRATCH', '.'), 'tmp'),
-    'kicp': os.path.join(os.environ.get('SCRATCH', '.'), 'tmp'),
-    'caslake': os.path.join(SCRATCH_DIR, 'tmp'),
+    "dali": os.path.expanduser(f"/dali/lgrandi/{USER}/tmp"),
+    "lgrandi": os.path.join(SCRATCH_DIR, "tmp"),
+    "xenon1t": os.path.join(SCRATCH_DIR, "tmp"),
+    "broadwl": os.path.join(SCRATCH_DIR, "tmp"),
+    "kicp": os.path.join(SCRATCH_DIR, "tmp"),
+    "caslake": os.path.join(SCRATCH_DIR, "tmp"),
 }
+SINGULARITY_DIR = {
+    "dali": "/dali/lgrandi/xenonnt/singularity-images",
+    "lgrandi": "/project2/lgrandi/xenonnt/singularity-images",
+    "xenon1t": "/project2/lgrandi/xenonnt/singularity-images",
+    "broadwl": "/project2/lgrandi/xenonnt/singularity-images",
+    "kicp": "/project2/lgrandi/xenonnt/singularity-images",
+    "caslake": "/project2/lgrandi/xenonnt/singularity-images",
+}
+DEFAULT_BIND = [
+    "/project2/lgrandi/xenonnt/dali:/dali",
+    "/project2",
+    "/project",
+    "/scratch/midway2/%s" % (USER),
+    "/scratch/midway3/%s" % (USER),
+]
+DALI_BIND = [
+    "/dali/lgrandi",
+    "/dali/lgrandi/xenonnt/xenon.config:/project2/lgrandi/xenonnt/xenon.config",
+    "/dali/lgrandi/grid_proxy/xenon_service_proxy:/project2/lgrandi/grid_proxy/xenon_service_proxy",
+]
 
 
-def overwrite_dali_bind(bind, partition):
-    """Check if we are binding non-dali storage when we are on dali compute node. If yes, then overwrite"""
-    if partition == 'dali':
-        bind = ['/dali/lgrandi', 
-                '/dali/lgrandi/xenonnt/xenon.config:/project2/lgrandi/xenonnt/xenon.config', 
-                '/dali/lgrandi/grid_proxy/xenon_service_proxy:/project2/lgrandi/grid_proxy/xenon_service_proxy'
-                ]
-        # print("You are using dali parition, and your bind has been fixed to %s"%(bind))
-    return bind
+def _make_executable(path: str) -> None:
+    """
+    Make a file executable by the user, group and others.
 
+    Args:
+        path (str): Path to the file to make executable.
 
-def wrong_log_dir(path):
-    """Check if the directory is NOT in dali"""
-    abs_path = os.path.abspath(path)
-    top_level = abs_path.split('/')[1] 
-    wrong_log_dir = False   
-    if top_level != 'dali':
-        wrong_log_dir = True
-    else:
-        wrong_log_dir = False
-    return wrong_log_dir
-
-
-def overwrite_dali_job_log(path, partition):
-    if partition == 'dali':
-        if wrong_log_dir(path):
-            logname = os.path.abspath(path).split('/')[-1]
-            new_path = TMPDIR['dali']+'/'+logname
-            print('Your log is relocated at: %s' % (new_path))
-            return new_path
-    print('Your log is located at: %s' % (os.path.abspath(path)))
-    return path
-
-
-def make_executable(path):
-    """Make the file at path executable, see """
+    Raises:
+        FileNotFoundError: If the file does not exist.
+    """
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"File {path} does not exist")
     mode = os.stat(path).st_mode
-    mode |= (mode & 0o444) >> 2    # copy R bits to X
+    mode |= (mode & 0o444) >> 2
     os.chmod(path, mode)
 
 
-def singularity_wrap(jobstring, image, bind, partition):
-    """Wraps a jobscript into another executable file that can be passed to singularity exec"""
-    file_descriptor, exec_file = tempfile.mkstemp(suffix='.sh', dir=TMPDIR[partition])
-    make_executable(exec_file)
-    os.write(file_descriptor, bytes('#!/bin/bash\n' + jobstring, 'utf-8'))
-    bind_string = " ".join([f"--bind {b}" for b in bind])
-    image = os.path.join(SINGULARITY_DIR[partition], image)
-    new_job_string = f"""singularity exec {bind_string} {image} {exec_file}
-exit_code=$?
-rm {exec_file}
-if [ $exit_code -ne 0 ]; then
-    echo "Python script failed with exit code $exit_code"
-    exit $exit_code
-fi
-"""
-    os.close(file_descriptor)
-    return new_job_string
+class JobSubmission(BaseModel):
+    jobstring: str = Field(..., description="The command to execute")
+    log: str = Field("job.log", description="Where to store the log file of the job")
+    partition: Literal["dali", "lgrandi", "xenon1t", "broadwl", "kicp", "caslake"] = Field(
+        "xenon1t", description="Partition to submit the job to"
+    )
+    qos: str = Field("xenon1t", description="QOS to submit the job to")
+    account: str = Field("pi-lgrandi", description="Account to submit the job to")
+    jobname: str = Field("somejob", description="How to name this job")
+    dry_run: bool = Field(
+        False, description="Only print how the job looks like, without submitting"
+    )
+    mem_per_cpu: int = Field(1000, description="MB requested for job")
+    container: str = Field(
+        "xenonnt-development.simg", description="Name of the container to activate"
+    )
+    bind: list[str] = Field(
+        default_factory=lambda: DEFAULT_BIND,
+        description="Paths to add to the container. Immutable when specifying dali as partition",
+    )
+    cpus_per_task: int = Field(1, description="CPUs requested for job")
+    hours: float = Field(None, description="Max hours of a job")
+    node: str = Field(None, description="Define a certain node to submit your job")
+    exclude_nodes: str = Field(
+        None, description="Define a list of nodes which should be excluded from submission"
+    )
+    dependency: str = Field(
+        None, description="Provide list of job ids to wait for before running this job"
+    )
 
+    @validator("bind", pre=True, each_item=True)
+    def check_bind(cls, v):
+        if not isinstance(v, str):
+            raise ValueError("Each bind must be a string")
 
+        if not os.path.exists(v):
+            raise FileNotFoundError(f"Bind path {v} does not exist")
 
-def submit_job(jobstring,
-               log='job.log',
-               partition='xenon1t',
-               qos='xenon1t',
-               account='pi-lgrandi',
-               jobname='somejob',
-               sbatch_file=None,
-               dry_run=False,
-               mem_per_cpu=1000,
-               container='xenonnt-development.simg',
-               bind=['/project2/lgrandi/xenonnt/dali:/dali', '/project2', '/project', '/scratch/midway2/%s'%(getpass.getuser()), '/scratch/midway3/%s'%(getpass.getuser())],
-               cpus_per_task=1,
-               hours=None,
-               node=None,
-               exclude_nodes=None,
-               dependency=None,
-               **kwargs
-               ):
-    """
-    Submit a job to the dali/midway batch queue
+        return v
 
-    EXAMPLE
-        from utilix import batchq
-        import time
+    @validator("partition", pre=True, always=True)
+    def check_partition(cls, v):
+        if v not in PARTITIONS:
+            raise ValueError(f"Partition must be one of {PARTITIONS}")
+        return v
 
-        job_log = 'job.log'
-        batchq.submit_job('echo "say hi"', log=job_log)
+    @validator("partition", pre=True, always=True)
+    def overwrite_for_dali(cls, v, values):
+        # You can access other fields in the model using the "values" dict
+        if v == "dali":
+            bind = DALI_BIND
+            values["bind"] = bind
+            logger.warning(f"Binds are overwritten to {bind}")
+            # If log path top level is not /dali
+            abs_log_path = os.path.abspath(values["log"])
+            if not abs_log_path.startswith("/dali"):
+                log_filename = os.path.basename(abs_log_path)
+                new_log_path = f"{TMPDIR['dali']}/{log_filename}"
+                values["log"] = new_log_path
+                print("Your log is relocated at: %s" % (new_log_path))
+                logger.warning(f"Log path is overwritten to {new_log_path}")
+        return v
 
-        time.sleep(10) # Allow the job to run
-        for line in open(job_log):
-            print(line)
+    @validator("hours")
+    def check_hours_value(cls, v):
+        if v is not None and (v <= 0 or v > 72):
+            raise ValueError("Hours must be between 0 and 72")
+        return v
 
-    :param jobstring: the command to execute
-    :param log: where to store the log file of the job
-    :param partition: partition to submit the job to
-    :param qos: qos to submit the job to
-    :param account: account to submit the job to
-    :param jobname: how to name this job
-    :param sbatch_file: where to write the job script to
-    :param dry_run: only print how the job looks like
-    :param mem_per_cpu: mb requested for job
-    :param container: name of the container to activate
-    :param bind: which paths to add to the container. This is immutable when you specified dali as partition
-    :param cpus_per_task: cpus requested for job
-    :param hours: max hours of a job
-    :param node: define a certain node to submit your job should be submitted to
-    :param exclude_nodes: define a list of nodes which should be excluded from submission
-    :param dependency: provide list of job ids to wait for before running this job
-    :param kwargs: are ignored
-    :return: None
-    """
-    if 'delete_file' in kwargs:
-        logger.warning('"delete_file" option for "submit_job" has been removed, ignoring for now')
-    os.makedirs(TMPDIR[partition], exist_ok=True)
-    # overwrite bind to make sure dali is isolated
-    bind = overwrite_dali_bind(bind, partition)
+    @validator("node", "exclude_nodes", "dependency")
+    def check_node_format(cls, v):
+        if v is not None and not re.match(r"^[a-zA-Z0-9,\[\]-]+$", v):
+            raise ValueError("Invalid format for node/exclude_nodes/dependency")
+        return v
 
-    # overwrite log directory if it is not on dali and you are running on dali.
-    log = overwrite_dali_job_log(log, partition)
+    @validator("container")
+    def check_container_format(cls, v):
+        if not v.endswith(".simg"):
+            raise ValueError("Container must end with .simg")
 
-    if container:
-        # need to wrap job into another executable
-        jobstring = singularity_wrap(jobstring, container, bind, partition)
+    def __init__(self, **data):
+        super().__init__(**data)
+        os.makedirs(TMPDIR[self.partition], exist_ok=True)
 
-        # if you have exported INSTALL_CUTAX to be 1, then you do NOT need to unset CUTAX_LOCATION
-        print("Your current CUTAX_LOCATION is %s"%(os.environ.get('CUTAX_LOCATION')))
-        if os.environ.get('INSTALL_CUTAX') != '1':
-            print("You have NOT exported INSTALL_CUTAX to be 1, so I will not unset CUTAX_LOCATION.")
-            jobstring = 'unset X509_CERT_DIR\n' + 'module load singularity\n' + jobstring
+    def __singularity_wrap(self) -> str:
+        """
+        Wrap the jobstring with the singularity command.
+
+        Raises:
+            FileNotFoundError: If the singularity image does not exist.
+
+        Returns:
+            str: The new jobstring with the singularity command.
+        """
+        if self.dry_run:
+            file_discriptor = None
+            exec_file = f"{TMPDIR[self.partition]}/tmp.sh"
         else:
-            print("You have exported INSTALL_CUTAX to be 1, so I will unset CUTAX_LOCATION for you.")
-            jobstring = 'unset X509_CERT_DIR CUTAX_LOCATION\n' + 'module load singularity\n' + jobstring
+            file_discriptor, exec_file = tempfile.mkstemp(suffix=".sh", dir=TMPDIR[self.partition])
+            _make_executable(exec_file)
+            os.write(file_discriptor, bytes("#!/bin/bash\n" + self.jobstring, "utf-8"))
+        bind_string = " ".join([f"--bind {b}" for b in self.bind])
+        image = os.path.join(SINGULARITY_DIR[self.partition], self.container)
+        if not os.path.exists(image):
+            raise FileNotFoundError(f"Singularity image {image} does not exist")
+        new_job_string = (
+            f"unset X509_CERT_DIR CUTAX_LOCATION\n"
+            f"module load singularity\n"
+            f"singularity exec {bind_string} {image} {exec_file}\n"
+            f"exit_code=$?\n"
+            f"rm {exec_file}\n"
+            f"if [ $exit_code -ne 0 ]; then\n"
+            f"    echo Python script failed with exit code $exit_code\n"
+            f"    exit $exit_code\n"
+            f"fi\n"
+        )
+        if file_discriptor is not None:
+            os.close(file_discriptor)
+        return new_job_string
 
-    if not hours is None:
-        hours = '#SBATCH --time={:02d}:{:02d}:{:02d}'.format(int(hours), int(hours * 60 % 60), int(hours * 60 % 60 * 60 % 60))
-    else:
-        hours = ''
+    def submit(self):
+        """
+        Submit the job to the SLURM queue.
+        """
+        # Initialize a dictionary with mandatory parameters
+        slurm_kwargs = {
+            "job_name": self.jobname,
+            "output": self.log,
+            "error": self.log,
+            "account": self.account,
+            "qos": self.qos,
+            "partition": self.partition,
+            "mem_per_cpu": self.mem_per_cpu,
+            "cpus_per_task": self.cpus_per_task,
+        }
 
-    if not node is None:
-        if not isinstance(node, str):
-            raise ValueError(f'node should be str but given {type(node)}')
-        node = '#SBATCH --nodelist={node}'.format(node=node)
-    else:
-        node = ''
+        # Conditionally add optional parameters if they are not None
+        if self.hours is not None:
+            slurm_kwargs["time"] = datetime.timedelta(hours=self.hours)
+        if self.node is not None:
+            slurm_kwargs["nodelist"] = self.node
+        if self.exclude_nodes is not None:
+            slurm_kwargs["exclude"] = self.exclude_nodes
+        if self.dependency is not None:
+            slurm_kwargs["dependency"] = {"afterok": self.dependency}
+            slurm_kwargs["kill_on_invalid"] = "yes"
 
-    if not exclude_nodes is None:
-        if not isinstance(exclude_nodes, str):
-            raise ValueError(f'exclude_nodes should be str but given {type(exclude_nodes)}')
-            # string like 'myCluster01,myCluster02,myCluster03' or 'myCluster[01-09]'
-        exclude_nodes = '#SBATCH --exclude={exclude_nodes}'.format(exclude_nodes=exclude_nodes)
-    else:
-        exclude_nodes = ''
+        # Create the Slurm instance with the conditional arguments
+        slurm = Slurm(**slurm_kwargs)
 
-    if not dependency is None:
-        if isinstance(dependency, list):
-            # Handle list of strings
-            job_ids = ":".join(dependency)
-        elif isinstance(dependency, str):
-            # Handle single string
-            job_ids = dependency
-        else:
-            raise ValueError(f'dependency should be list or str but given {type(dependency)}')
-        
-        dependency = "--dependency=afterok:"+job_ids+" --kill-on-invalid-dep=yes"
-    
-    else:
-        dependency = ''
+        # Process the jobstring with the container if specified
+        if self.container is not None:
+            self.jobstring = self.__singularity_wrap(
+                self.jobstring, self.container, self.bind, self.partition
+            )
 
+        # Add the job command
+        slurm.add_cmd(self.jobstring)
+
+        print(f"Your log is located at: {self.log}")
+
+        # Handle dry run scenario
+        if self.dry_run:
+            print(slurm)
+            return
+
+        # Submit the job
+        slurm.sbatch()
 
 
-    sbatch_script = sbatch_template.format(jobname=jobname, log=log, qos=qos, partition=partition,
-                                           account=account, job=jobstring, mem_per_cpu=mem_per_cpu,
-                                           cpus_per_task=cpus_per_task, hours=hours, node=node,
-                                           exclude_nodes=exclude_nodes)
+def submit_jobs(**kwargs):
+    """
+    Adapter to old function name.
+    You should use JobSubmission to get modern code editor support.
 
-    if dry_run:
-        print("=== DRY RUN ===")
-        print(sbatch_script)
-        return
+    Args:
+        **kwargs: Keyword arguments to pass to JobSubmission
+    """
+    logger.warning(
+        "Using legacy function name, please use JobSubmission to get modern code editor support"
+    )
+    job = JobSubmission(**kwargs)
+    job.submit()
 
-    if sbatch_file is None:
-        remove_file = True
-        _, sbatch_file = tempfile.mkstemp(suffix='.sbatch')
-    else:
-        remove_file = False
 
-    with open(sbatch_file, 'w') as f:
-        f.write(sbatch_script)
+def count_jobs() -> int:
+    """
+    Count the number of jobs in the queue.
 
-    command = "sbatch %s %s" % (dependency, sbatch_file)
-    if not sbatch_file:
-        print("Executing: %s" % command)
-
-    process = subprocess.Popen(shlex.split(command), stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
-    output, error = process.communicate()
- 
-
-    # Check if the job submission was successful
-    if process.returncode == 0:
-        # Extract the job ID from the output
-        job_id = output.decode().strip().split()[-1]
-    else:
-        job_id = None
-        # Handle the case where the job submission failed
-        print("Job submission failed:", error.decode())
-        
-    if remove_file:
-        os.remove(sbatch_file)
-
-    return job_id
-
-def count_jobs(string=''):
-    username = os.environ.get("USER")
-    output = subprocess.check_output(shlex.split("squeue -u %s" % username))
-    lines = output.decode('utf-8').split('\n')
-    return len([job for job in lines if string in job])
-
+    Returns:
+        int: The number of jobs in the queue.
+    """
+    cmd = f"squeue -u {USER}"
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True, shell=True)
+        lines = result.stdout.strip().split("\n")
+        # Subtract 1 for the header; if no jobs, ensure it returns 0 instead of -1
+        return max(len(lines) - 1, 0)
+    except subprocess.CalledProcessError as e:
+        print(f"An error occurred while executing squeue: {e}")
+        return 0

--- a/utilix/batchq.py
+++ b/utilix/batchq.py
@@ -118,7 +118,7 @@ class JobSubmission(BaseModel):
     verbose: bool = Field(False, description="Print the sbatch command before submitting")
 
     @validator("bind", pre=True, each_item=True)
-    def check_bind(cls, v):
+    def check_bind(cls, v) -> str:
         if not isinstance(v, str):
             raise ValueError("Each bind must be a string")
 
@@ -128,7 +128,7 @@ class JobSubmission(BaseModel):
         return v
 
     @validator("partition", pre=True, always=True)
-    def overwrite_for_dali(cls, v, values):
+    def overwrite_for_dali(cls, v, values) -> str:
         # You can access other fields in the model using the "values" dict
         if v == "dali":
             bind = DALI_BIND
@@ -145,7 +145,7 @@ class JobSubmission(BaseModel):
         return v
 
     @validator("qos", pre=True, always=True)
-    def check_qos(cls, v):
+    def check_qos(cls, v) -> str:
         qos_list = _get_qos_list()
         if v not in qos_list:
             logger.warning(
@@ -155,19 +155,19 @@ class JobSubmission(BaseModel):
         return v
 
     @validator("hours")
-    def check_hours_value(cls, v):
+    def check_hours_value(cls, v) -> Optional[float]:
         if v is not None and (v <= 0 or v > 72):
             raise ValueError("Hours must be between 0 and 72")
         return v
 
     @validator("node", "exclude_nodes", "dependency")
-    def check_node_format(cls, v):
+    def check_node_format(cls, v) -> Optional[str]:
         if v is not None and not re.match(r"^[a-zA-Z0-9,\[\]-]+$", v):
             raise ValueError("Invalid format for node/exclude_nodes/dependency")
         return v
 
     @validator("container")
-    def check_container_format(cls, v):
+    def check_container_format(cls, v) -> str:
         if not v.endswith(".simg"):
             raise ValueError("Container must end with .simg")
         # Check if the container exists
@@ -178,7 +178,7 @@ class JobSubmission(BaseModel):
         return v
 
     @validator("sbatch_file")
-    def check_sbatch_file(cls, v):
+    def check_sbatch_file(cls, v) -> Optional[str]:
         if v is not None:
             logger.warning("sbatch_file is deprecated")
         return v
@@ -302,6 +302,6 @@ def count_jobs(string="") -> int:
     Returns:
         int: Number of jobs in the queue.
     """
-    output = subprocess.check_output(["squeue", "-u", USER]).decode("utf-8")
+    output = subprocess.check_output(["squeue", "-u", str(USER)]).decode("utf-8")
     lines = output.split("\n")
     return len([job for job in lines if string in job])

--- a/utilix/batchq.py
+++ b/utilix/batchq.py
@@ -170,6 +170,11 @@ class JobSubmission(BaseModel):
     def check_container_format(cls, v):
         if not v.endswith(".simg"):
             raise ValueError("Container must end with .simg")
+        # Check if the container exists
+        if not os.path.exists(os.path.join(SINGULARITY_DIR[cls.partition], v)):
+            raise FileNotFoundError(
+                f"Singularity image {v} does not exist in {SINGULARITY_DIR[cls.partition]}"
+            )
         return v
 
     @validator("sbatch_file")

--- a/utilix/batchq.py
+++ b/utilix/batchq.py
@@ -194,7 +194,8 @@ class JobSubmission(BaseModel):
         if not os.path.exists(image):
             raise FileNotFoundError(f"Singularity image {image} does not exist")
         new_job_string = (
-            f"unset X509_CERT_DIR CUTAX_LOCATION\n"
+            f"unset X509_CERT_DIR\n"
+            f'if [ "$INSTALL_CUTAX" == "1" ]; then unset CUTAX_LOCATION; fi\n'
             f"module load singularity\n"
             f"singularity exec {bind_string} {image} {exec_file}\n"
             f"exit_code=$?\n"

--- a/utilix/batchq.py
+++ b/utilix/batchq.py
@@ -183,9 +183,6 @@ class JobSubmission(BaseModel):
             logger.warning("sbatch_file is deprecated")
         return v
 
-    def __init__(self, **data):
-        super().__init__(**data)
-
     def _create_singularity_jobstring(self) -> str:
         """
         Wrap the jobstring with the singularity command.

--- a/utilix/batchq.py
+++ b/utilix/batchq.py
@@ -231,7 +231,7 @@ class JobSubmission(BaseModel):
         """
         os.makedirs(TMPDIR[self.partition], exist_ok=True)
         # Initialize a dictionary with mandatory parameters
-        slurm_kwargs = {
+        slurm_params = {
             "job_name": self.jobname,
             "output": self.log,
             "qos": self.qos,
@@ -244,17 +244,17 @@ class JobSubmission(BaseModel):
 
         # Conditionally add optional parameters if they are not None
         if self.hours is not None:
-            slurm_kwargs["time"] = datetime.timedelta(hours=self.hours)
+            slurm_params["time"] = datetime.timedelta(hours=self.hours)
         if self.node is not None:
-            slurm_kwargs["nodelist"] = self.node
+            slurm_params["nodelist"] = self.node
         if self.exclude_nodes is not None:
-            slurm_kwargs["exclude"] = self.exclude_nodes
+            slurm_params["exclude"] = self.exclude_nodes
         if self.dependency is not None:
-            slurm_kwargs["dependency"] = {"afterok": self.dependency}
-            slurm_kwargs["kill_on_invalid"] = "yes"
+            slurm_params["dependency"] = {"afterok": self.dependency}
+            slurm_params["kill_on_invalid"] = "yes"
 
         # Create the Slurm instance with the conditional arguments
-        slurm = Slurm(**slurm_kwargs)
+        slurm = Slurm(**slurm_params)
 
         # Process the jobstring with the container if specified
         if self.container is not None:

--- a/utilix/batchq.py
+++ b/utilix/batchq.py
@@ -128,12 +128,6 @@ class JobSubmission(BaseModel):
         return v
 
     @validator("partition", pre=True, always=True)
-    def check_partition(cls, v):
-        if v not in PARTITIONS:
-            raise ValueError(f"Partition must be one of {PARTITIONS}")
-        return v
-
-    @validator("partition", pre=True, always=True)
     def overwrite_for_dali(cls, v, values):
         # You can access other fields in the model using the "values" dict
         if v == "dali":

--- a/utilix/batchq.py
+++ b/utilix/batchq.py
@@ -165,6 +165,7 @@ class JobSubmission(BaseModel):
     def check_container_format(cls, v):
         if not v.endswith(".simg"):
             raise ValueError("Container must end with .simg")
+        return v
 
     def __init__(self, **data):
         super().__init__(**data)


### PR DESCRIPTION
I refactored batchq.py to implement #85
Changes include:
- Using [simple_slurm](https://github.com/amq92/simple_slurm) for more generic and robust sbatch script generation.
- Using [pydantic](https://github.com/pydantic/pydantic) for data validation. This validates user inputs before any job submission and provides us with better error messages to reduce human errors.
- Updating version number to `0.8.0`.
- Updating documentation.