### PR TITLE
Clear error type

### DIFF
--- a/tests/test_batchq.py
+++ b/tests/test_batchq.py
@@ -1,0 +1,65 @@
+import os
+from typing import Dict, Any
+from copy import deepcopy
+from pydantic import ValidationError
+from utilix.batchq import JobSubmission, QOSNotFoundError, FormatError
+import pytest
+from unittest.mock import patch
+
+import os
+from typing import Dict, Any
+from pydantic import ValidationError
+from utilix.batchq import JobSubmission, QOSNotFoundError
+import pytest
+from unittest.mock import patch
+
+# Fixture to provide a sample valid JobSubmission instance
+@pytest.fixture
+def valid_job_submission() -> JobSubmission:
+    return JobSubmission(
+        jobstring="Hello World",
+        qos="xenon1t",
+        hours=10,
+        container="xenonnt-development.simg",
+    )
+
+def test_valid_jobstring(valid_job_submission: JobSubmission):
+    """ Test case to check if a valid jobstring is accepted. """
+    assert valid_job_submission.jobstring == "Hello World"
+
+def test_invalid_qos():
+    """ Test case to check if the appropriate validation error is raised when an invalid value is provided for the qos field. """
+    with pytest.raises(QOSNotFoundError) as exc_info:
+        JobSubmission(jobstring="Hello World", qos="invalid_qos", hours=10, container="xenonnt-development.simg")
+    assert "QOS invalid_qos is not in the list of available qos" in str(exc_info.value)
+
+def test_valid_qos(valid_job_submission: JobSubmission):
+    """ Test case to check if a valid qos is accepted. """
+    assert valid_job_submission.qos == "xenon1t"
+
+def test_invalid_hours():
+    """ Test case to check if the appropriate validation error is raised when an invalid value is provided for the hours field. """
+    with pytest.raises(ValidationError) as exc_info:
+        JobSubmission(jobstring="Hello World", qos="xenon1t", hours=100, container="xenonnt-development.simg")
+    assert "Hours must be between 0 and 72" in str(exc_info.value)
+
+def test_valid_hours(valid_job_submission: JobSubmission):
+    """ Test case to check if a valid hours value is accepted. """
+    assert valid_job_submission.hours == 10
+
+def test_invalid_container():
+    """ Test case to check if the appropriate validation error is raised when an invalid value is provided for the container field. """
+    with pytest.raises(FormatError) as exc_info:
+        JobSubmission(jobstring="Hello World", qos="xenon1t", hours=10, container="invalid.ext")
+    assert "Container must end with .simg" in str(exc_info.value)
+
+def test_valid_container(valid_job_submission: JobSubmission):
+    """ Test case to check if a valid container value is accepted. """
+    assert valid_job_submission.container == "xenonnt-development.simg"
+
+def test_container_exists(valid_job_submission: JobSubmission, tmp_path: str):
+    """ Test case to check if the appropriate validation error is raised when the specified container does not exist. """
+    with patch.dict("utilix.batchq.SINGULARITY_DIR", {"xenon1t": str(tmp_path)}):
+        with pytest.raises(FileNotFoundError) as exc_info:
+            JobSubmission(**valid_job_submission.dict())
+        assert "Singularity image xenonnt-development.simg does not exist" in str(exc_info.value)

--- a/tests/test_batchq.py
+++ b/tests/test_batchq.py
@@ -23,43 +23,110 @@ def valid_job_submission() -> JobSubmission:
         container="xenonnt-development.simg",
     )
 
+
 def test_valid_jobstring(valid_job_submission: JobSubmission):
-    """ Test case to check if a valid jobstring is accepted. """
+    """Test case to check if a valid jobstring is accepted."""
     assert valid_job_submission.jobstring == "Hello World"
 
+
 def test_invalid_qos():
-    """ Test case to check if the appropriate validation error is raised when an invalid value is provided for the qos field. """
+    """Test case to check if the appropriate validation error is raised when an invalid value is provided for the qos field."""
     with pytest.raises(QOSNotFoundError) as exc_info:
-        JobSubmission(jobstring="Hello World", qos="invalid_qos", hours=10, container="xenonnt-development.simg")
+        JobSubmission(
+            jobstring="Hello World",
+            qos="invalid_qos",
+            hours=10,
+            container="xenonnt-development.simg",
+        )
     assert "QOS invalid_qos is not in the list of available qos" in str(exc_info.value)
 
+
 def test_valid_qos(valid_job_submission: JobSubmission):
-    """ Test case to check if a valid qos is accepted. """
+    """Test case to check if a valid qos is accepted."""
     assert valid_job_submission.qos == "xenon1t"
 
+
 def test_invalid_hours():
-    """ Test case to check if the appropriate validation error is raised when an invalid value is provided for the hours field. """
+    """Test case to check if the appropriate validation error is raised when an invalid value is provided for the hours field."""
     with pytest.raises(ValidationError) as exc_info:
-        JobSubmission(jobstring="Hello World", qos="xenon1t", hours=100, container="xenonnt-development.simg")
+        JobSubmission(
+            jobstring="Hello World",
+            qos="xenon1t",
+            hours=100,
+            container="xenonnt-development.simg",
+        )
     assert "Hours must be between 0 and 72" in str(exc_info.value)
 
+
 def test_valid_hours(valid_job_submission: JobSubmission):
-    """ Test case to check if a valid hours value is accepted. """
+    """Test case to check if a valid hours value is accepted."""
     assert valid_job_submission.hours == 10
 
+
 def test_invalid_container():
-    """ Test case to check if the appropriate validation error is raised when an invalid value is provided for the container field. """
+    """Test case to check if the appropriate validation error is raised when an invalid value is provided for the container field."""
     with pytest.raises(FormatError) as exc_info:
-        JobSubmission(jobstring="Hello World", qos="xenon1t", hours=10, container="invalid.ext")
+        JobSubmission(
+            jobstring="Hello World", qos="xenon1t", hours=10, container="invalid.ext"
+        )
     assert "Container must end with .simg" in str(exc_info.value)
 
+
 def test_valid_container(valid_job_submission: JobSubmission):
-    """ Test case to check if a valid container value is accepted. """
+    """Test case to check if a valid container value is accepted."""
     assert valid_job_submission.container == "xenonnt-development.simg"
 
+
 def test_container_exists(valid_job_submission: JobSubmission, tmp_path: str):
-    """ Test case to check if the appropriate validation error is raised when the specified container does not exist. """
+    """Test case to check if the appropriate validation error is raised when the specified container does not exist."""
     with patch.dict("utilix.batchq.SINGULARITY_DIR", {"xenon1t": str(tmp_path)}):
         with pytest.raises(FileNotFoundError) as exc_info:
             JobSubmission(**valid_job_submission.dict())
-        assert "Singularity image xenonnt-development.simg does not exist" in str(exc_info.value)
+        assert "Singularity image xenonnt-development.simg does not exist" in str(
+            exc_info.value
+        )
+
+def test_bypass_validation_qos(valid_job_submission: JobSubmission):
+    """
+    Test case to check if the validation for the qos field is skipped when it is included in the bypass_validation list.
+    """
+    job_submission_data = valid_job_submission.dict().copy()
+    job_submission_data["qos"] = "invalid_qos"
+    job_submission_data["bypass_validation"] = ["qos"] + job_submission_data.get("bypass_validation", [])
+    job_submission = JobSubmission(**job_submission_data)
+    assert job_submission.qos == "invalid_qos"
+
+def test_bypass_validation_hours(valid_job_submission: JobSubmission):
+    """
+    Test case to check if the validation for the hours field is skipped when it is included in the bypass_validation list.
+    """
+    job_submission_data = valid_job_submission.dict().copy()
+    job_submission_data["hours"] = 100
+    job_submission_data["bypass_validation"] = ["hours"] + job_submission_data.get("bypass_validation", [])
+    job_submission = JobSubmission(**job_submission_data)
+    assert job_submission.hours == 100
+
+
+def test_bypass_validation_container(valid_job_submission: JobSubmission):
+    """
+    Test case to check if the validation for the container field is skipped when it is included in the bypass_validation list.
+    """
+    job_submission_data = valid_job_submission.dict().copy()
+    job_submission_data["container"] = "invalid.ext"
+    job_submission_data["bypass_validation"] = ["container"] + job_submission_data.get("bypass_validation", [])
+    job_submission = JobSubmission(**job_submission_data)
+    assert job_submission.container == "invalid.ext"
+
+def test_bypass_validation_multiple_fields(valid_job_submission: JobSubmission):
+    """
+    Test case to check if the validation for multiple fields is skipped when they are included in the bypass_validation list.
+    """
+    job_submission_data = valid_job_submission.dict().copy()
+    job_submission_data["qos"] = "invalid_qos"
+    job_submission_data["hours"] = 100
+    job_submission_data["container"] = "invalid.ext"
+    job_submission_data["bypass_validation"] = ["qos", "hours", "container"] + job_submission_data.get("bypass_validation", [])
+    job_submission = JobSubmission(**job_submission_data)
+    assert job_submission.qos == "invalid_qos"
+    assert job_submission.hours == 100
+    assert job_submission.container == "invalid.ext"

--- a/utilix/batchq.py
+++ b/utilix/batchq.py
@@ -64,18 +64,15 @@ DALI_BIND: List[str] = [
     "/dali/lgrandi/grid_proxy/xenon_service_proxy:/project2/lgrandi/grid_proxy/xenon_service_proxy",
 ]
 
-
 class QOSNotFoundError(Exception):
     """
     Provided qos is not found in the qos list
     """
-
-
+    
 class FormatError(Exception):
     """
     Format of file is not correct
     """
-
 
 def _make_executable(path: str) -> None:
     """
@@ -112,7 +109,6 @@ def _get_qos_list() -> List[str]:
     except subprocess.CalledProcessError as e:
         print(f"An error occurred while executing sacctmgr: {e}")
         return []
-
 
 class JobSubmission(BaseModel):
     """

--- a/utilix/batchq.py
+++ b/utilix/batchq.py
@@ -476,6 +476,7 @@ class JobSubmission(BaseModel):
 
 def submit_job(
     jobstring: str,
+    bypass_validation: List[str] = [],
     exclude_lc_nodes: bool = True,
     log: str = "job.log",
     partition: Literal[
@@ -543,6 +544,7 @@ def submit_job(
         exclude_nodes=exclude_nodes,
         dependency=dependency,
         verbose=verbose,
+        bypass_validation=bypass_validation,
     )
     job.submit()
 


### PR DESCRIPTION
- Add clear error type like `QOSNotFoundError`. So that users could do the following to bypass some of the validators:
```
try:
    job_submission=JobSubmission()
except QOSNotFoundError:
    pass
```

- Add a unittest for batchq