### PR TITLE
Set default `bypass_validation` as empty list

### DIFF
--- a/utilix/batchq.py
+++ b/utilix/batchq.py
@@ -185,7 +185,7 @@ class JobSubmission(BaseModel):
     
     # validate the bypass_validation so that it can be reached in values
     @validator("bypass_validation", pre=True, each_item=True)
-    def check_bypass_validation(cls, v: str) -> str:
+    def check_bypass_validation(cls, v: list) -> list:
         return v
 
     @validator("bind", pre=True, each_item=True)
@@ -247,8 +247,6 @@ class JobSubmission(BaseModel):
             str: The qos to use.
         """
         if cls._skip_validation("qos", values):
-            return v
-        if "qos" in values.get("bypass_validation", []):
             return v
         qos_list = _get_qos_list()
         if v not in qos_list:
@@ -495,7 +493,7 @@ def submit_job(
     exclude_nodes: Optional[str] = None,
     dependency: Optional[str] = None,
     verbose: bool = False,
-    bypass_validation: Optional[List[str]] = None,
+    bypass_validation: Optional[List[str]] = [],
 ) -> None:
     """
     Submit a job to the SLURM queue.


### PR DESCRIPTION
Before this PR, when submitting any job, an error shows:
```
pydantic.error_wrappers.ValidationError: 1 validation error for JobSubmission
bypass_validation
  none is not an allowed value (type=type_error.none.not_allowed)
```
because we assigned default `bypass_validation` as `None`:
https://github.com/XENONnT/utilix/blob/6c39370a8f5c972571b0366bdee78abcec69da9e/utilix/batchq.py#L498