### PR TITLE
Fix dali binding

### DIFF
--- a/tests/test_batchq.py
+++ b/tests/test_batchq.py
@@ -11,6 +11,7 @@ import inspect
 def valid_job_submission() -> JobSubmission:
     return JobSubmission(
         jobstring="Hello World",
+        partition="xenon1t",
         qos="xenon1t",
         hours=10,
         container="xenonnt-development.simg",
@@ -151,3 +152,5 @@ def test_submit_job_arguments():
     assert (
         len(missing_params) == 0
     ), f"Missing parameters in submit_job: {', '.join(missing_params)}"
+
+    

--- a/utilix/batchq.py
+++ b/utilix/batchq.py
@@ -123,6 +123,10 @@ class JobSubmission(BaseModel):
         False, description="Exclude the loosely coupled nodes"
     )
     log: str = Field("job.log", description="Where to store the log file of the job")
+    bind: List[str] = Field(
+        default_factory=lambda: DEFAULT_BIND,
+        description="Paths to add to the container. Immutable when specifying dali as partition",
+    )
     partition: Literal[
         "dali", "lgrandi", "xenon1t", "broadwl", "kicp", "caslake", "build"
     ] = Field("xenon1t", description="Partition to submit the job to")
@@ -136,10 +140,6 @@ class JobSubmission(BaseModel):
     mem_per_cpu: int = Field(1000, description="MB requested for job")
     container: str = Field(
         "xenonnt-development.simg", description="Name of the container to activate"
-    )
-    bind: List[str] = Field(
-        default_factory=lambda: DEFAULT_BIND,
-        description="Paths to add to the container. Immutable when specifying dali as partition",
     )
     cpus_per_task: int = Field(1, description="CPUs requested for job")
     hours: Optional[float] = Field(None, description="Max hours of a job")


### PR DESCRIPTION
Pydantic validators are called according to the sequence of the input arguments. In the old code "bind" was behind "partition", so the binding reset for dali https://github.com/XENONnT/utilix/blob/4bf968290ecaa96f8ae6c9cf16f6c9f75add3813/utilix/batchq.py#L211
doesn't actually work, as the bind will be overwritten in the bind validator.

This PR fixes this problem by moving "bind" in front of "partition"
