### PR TITLE
Auto check binding

### DIFF
--- a/tests/test_batchq.py
+++ b/tests/test_batchq.py
@@ -5,6 +5,7 @@ import pytest
 import os
 from unittest.mock import patch
 import inspect
+import logging
 
 
 # Get the SERVER type
@@ -56,54 +57,6 @@ def test_valid_jobstring(valid_job_submission: JobSubmission):
     assert valid_job_submission.jobstring == "Hello World"
 
 
-def test_invalid_qos():
-    """Test case to check if the appropriate validation error is raised when an invalid value is provided for the qos field."""
-    with pytest.raises(QOSNotFoundError) as exc_info:
-        JobSubmission(
-            jobstring="Hello World",
-            qos="invalid_qos",
-            hours=10,
-            container="xenonnt-development.simg",
-        )
-    assert "QOS invalid_qos is not in the list of available qos" in str(exc_info.value)
-
-
-def test_valid_qos(valid_job_submission: JobSubmission):
-    """Test case to check if a valid qos is accepted."""
-    assert valid_job_submission.qos == valid_job_submission.qos
-
-
-def test_invalid_hours():
-    """Test case to check if the appropriate validation error is raised when an invalid value is provided for the hours field."""
-    with pytest.raises(ValidationError) as exc_info:
-        JobSubmission(
-            jobstring="Hello World",
-            partition=PARTITION,
-            qos=QOS,
-            hours=100,
-            container="xenonnt-development.simg",
-        )
-    assert "Hours must be between 0 and 72" in str(exc_info.value)
-
-
-def test_valid_hours(valid_job_submission: JobSubmission):
-    """Test case to check if a valid hours value is accepted."""
-    assert valid_job_submission.hours == valid_job_submission.hours
-
-
-def test_invalid_container():
-    """Test case to check if the appropriate validation error is raised when an invalid value is provided for the container field."""
-    with pytest.raises(FormatError) as exc_info:
-        JobSubmission(
-            jobstring="Hello World",
-            partition=PARTITION,
-            qos=QOS,
-            hours=10,
-            container="invalid.ext",
-        )
-    assert "Container must end with .simg" in str(exc_info.value)
-
-
 def test_valid_container(valid_job_submission: JobSubmission):
     """Test case to check if a valid path for the container is found."""
     assert "xenonnt-development.simg" in valid_job_submission.container
@@ -121,6 +74,55 @@ def test_container_exists(valid_job_submission: JobSubmission, tmp_path: str):
                 container=invalid_container,
             )
         assert f"Container {invalid_container} does not exist" in str(exc_info.value)
+
+
+def test_invalid_container(valid_job_submission: JobSubmission):
+    """Test case to check if the appropriate validation error is raised when an invalid value is provided for the container field."""
+    job_submission_data = valid_job_submission.dict().copy()
+    job_submission_data["container"] = "invalid.txt"
+    with pytest.raises(FormatError) as exc_info:
+        job_submission = JobSubmission(**job_submission_data)
+    assert "Container must end with .simg" in str(exc_info.value)
+
+
+def test_invalid_qos(valid_job_submission: JobSubmission):
+    """Test case to check if the appropriate validation error is raised when an invalid value is provided for the qos field."""
+    job_submission_data = valid_job_submission.dict().copy()
+    job_submission_data["qos"] = "invalid_qos"
+    with pytest.raises(QOSNotFoundError) as exc_info:
+        JobSubmission(**job_submission_data)
+    assert "QOS invalid_qos is not in the list of available qos" in str(exc_info.value)
+
+
+def test_valid_qos(valid_job_submission: JobSubmission):
+    """Test case to check if a valid qos is accepted."""
+    assert valid_job_submission.qos == valid_job_submission.qos
+
+
+def test_invalid_bind(valid_job_submission: JobSubmission, caplog):
+    """Test case to check if the appropriate validation error is raised when an invalid value is provided for the bind field."""
+    job_submission_data = valid_job_submission.dict().copy()
+    invalid_bind = "/project999"
+    job_submission_data["bind"].append(invalid_bind)
+    with caplog.at_level(logging.WARNING):
+        JobSubmission(**job_submission_data)
+
+    assert "skipped mounting" in caplog.text
+    assert invalid_bind in caplog.text
+
+
+def test_invalid_hours(valid_job_submission: JobSubmission):
+    """Test case to check if the appropriate validation error is raised when an invalid value is provided for the hours field."""
+    job_submission_data = valid_job_submission.dict().copy()
+    job_submission_data["hours"] = 1000
+    with pytest.raises(ValidationError) as exc_info:
+        JobSubmission(**job_submission_data)
+    assert "Hours must be between 0 and 72" in str(exc_info.value)
+
+
+def test_valid_hours(valid_job_submission: JobSubmission):
+    """Test case to check if a valid hours value is accepted."""
+    assert valid_job_submission.hours == valid_job_submission.hours
 
 
 def test_bypass_validation_qos(valid_job_submission: JobSubmission):

--- a/tests/test_batchq.py
+++ b/tests/test_batchq.py
@@ -11,6 +11,7 @@ import inspect
 def valid_job_submission() -> JobSubmission:
     return JobSubmission(
         jobstring="Hello World",
+        partition="xenon1t",
         qos="xenon1t",
         hours=10,
         container="xenonnt-development.simg",
@@ -151,3 +152,5 @@ def test_submit_job_arguments():
     assert (
         len(missing_params) == 0
     ), f"Missing parameters in submit_job: {', '.join(missing_params)}"
+
+    

--- a/tests/test_batchq.py
+++ b/tests/test_batchq.py
@@ -2,17 +2,39 @@ from pydantic import ValidationError
 from utilix import batchq
 from utilix.batchq import JobSubmission, QOSNotFoundError, FormatError, submit_job
 import pytest
+import os
 from unittest.mock import patch
 import inspect
 
+# Get the server type
+def get_server_type():
+    hostname = os.uname().nodename
+    if "midway2" in hostname:
+        return "Midway2"
+    elif "midway3" in hostname:
+        return "Midway3"
+    elif "dali" in hostname:
+        return "Dali"
+    else:
+        raise ValueError(f"Unknown server type for hostname {hostname}. Please use midway2, midway3, or dali.")
 
 # Fixture to provide a sample valid JobSubmission instance
 @pytest.fixture
 def valid_job_submission() -> JobSubmission:
+    server = get_server_type()
+    if server == "Midway2":
+        partition = "xenon1t"
+        qos = "xenon1t"
+    elif server == "Midway3":
+        partition = "lgrandi"
+        qos = "lgrandi"
+    elif server == "Dali":
+        partition = "dali"
+        qos = "dali"   
     return JobSubmission(
         jobstring="Hello World",
-        partition="xenon1t",
-        qos="xenon1t",
+        partition=partition,
+        qos=qos,
         hours=10,
         container="xenonnt-development.simg",
     )

--- a/utilix/batchq.py
+++ b/utilix/batchq.py
@@ -123,6 +123,10 @@ class JobSubmission(BaseModel):
         False, description="Exclude the loosely coupled nodes"
     )
     log: str = Field("job.log", description="Where to store the log file of the job")
+    bind: List[str] = Field(
+        default_factory=lambda: DEFAULT_BIND,
+        description="Paths to add to the container. Immutable when specifying dali as partition",
+    )
     partition: Literal[
         "dali", "lgrandi", "xenon1t", "broadwl", "kicp", "caslake", "build"
     ] = Field("xenon1t", description="Partition to submit the job to")
@@ -136,10 +140,6 @@ class JobSubmission(BaseModel):
     mem_per_cpu: int = Field(1000, description="MB requested for job")
     container: str = Field(
         "xenonnt-development.simg", description="Name of the container to activate"
-    )
-    bind: List[str] = Field(
-        default_factory=lambda: DEFAULT_BIND,
-        description="Paths to add to the container. Immutable when specifying dali as partition",
     )
     cpus_per_task: int = Field(1, description="CPUs requested for job")
     hours: Optional[float] = Field(None, description="Max hours of a job")


### PR DESCRIPTION
As discussed in [this slack thread](https://xenonnt.slack.com/archives/C017J7ELYU8/p1716524566325289), the instability of mounting affects the performance of `env_starter` and `batchq`. 
To avoid manually modifying the codes based on the variant status of servers, a better practice is to put all possible bindings and image locations in those two modules and do an automatic check to avoid problematic ones. By doing that, we can guarantee that users will get all of the possible resources without touching the inner side of the tools. The implementation of image location checking was done in #108, and here, we also added a similar function to the binding. 

The unit tests are also updated accordingly. I have run the tests on midway2, midway3 and dali and on all servers they are working well.