### PR TITLE
Change read preference

### DIFF
--- a/tests/test_batchq.py
+++ b/tests/test_batchq.py
@@ -11,6 +11,7 @@ import inspect
 def valid_job_submission() -> JobSubmission:
     return JobSubmission(
         jobstring="Hello World",
+        partition="xenon1t",
         qos="xenon1t",
         hours=10,
         container="xenonnt-development.simg",
@@ -151,3 +152,5 @@ def test_submit_job_arguments():
     assert (
         len(missing_params) == 0
     ), f"Missing parameters in submit_job: {', '.join(missing_params)}"
+
+    

--- a/utilix/batchq.py
+++ b/utilix/batchq.py
@@ -123,6 +123,10 @@ class JobSubmission(BaseModel):
         False, description="Exclude the loosely coupled nodes"
     )
     log: str = Field("job.log", description="Where to store the log file of the job")
+    bind: List[str] = Field(
+        default_factory=lambda: DEFAULT_BIND,
+        description="Paths to add to the container. Immutable when specifying dali as partition",
+    )
     partition: Literal[
         "dali", "lgrandi", "xenon1t", "broadwl", "kicp", "caslake", "build"
     ] = Field("xenon1t", description="Partition to submit the job to")
@@ -136,10 +140,6 @@ class JobSubmission(BaseModel):
     mem_per_cpu: int = Field(1000, description="MB requested for job")
     container: str = Field(
         "xenonnt-development.simg", description="Name of the container to activate"
-    )
-    bind: List[str] = Field(
-        default_factory=lambda: DEFAULT_BIND,
-        description="Paths to add to the container. Immutable when specifying dali as partition",
     )
     cpus_per_task: int = Field(1, description="CPUs requested for job")
     hours: Optional[float] = Field(None, description="Max hours of a job")

--- a/utilix/rundb.py
+++ b/utilix/rundb.py
@@ -535,7 +535,7 @@ def pymongo_collection(collection='runs', **kwargs):
     if not database:
         database = uconfig.get('RunDB', 'pymongo_database')
     uri = uri.format(user=user, pw=pw, url=url)
-    c = pymongo.MongoClient(uri, readPreference='secondaryPreferred')
+    c = pymongo.MongoClient(uri, readPreference='secondary')
     DB = c[database]
     coll = DB[collection]
     # Checkout the collection we are returning and raise errors if you want


### PR DESCRIPTION
In the current `rundb.py` the read preference for the MongoDB client is set to be `SecondaryPreffered`. But it doesn't stop the client from reading from the primary when the secondaries are not available. As the network bandwidth of the primary one is not satisfactory, we should avoid reading from the primary and just read from the secondaries.

Reference: the documentation of `pymongo` about the read preference:
https://pymongo.readthedocs.io/en/stable/api/pymongo/read_preferences.html