### PR TITLE
Exempt `OSError` for `Tarball.get_installed_git_repo`

### DIFF
--- a/utilix/tarball.py
+++ b/utilix/tarball.py
@@ -77,7 +77,7 @@ class Tarball:
         try:
             repo = Repo(mod.__path__[0], search_parent_directories=True)
             return repo
-        except InvalidGitRepositoryError:
+        except (OSError, InvalidGitRepositoryError):
             return
 
     @staticmethod


### PR DESCRIPTION
Without this PR, we will see:
```
Traceback (most recent call last):
  File "/home/xudc/tt.py", line 4, in <module>
    Tarball.get_installed_git_repo("rucio")
  File "/home/xudc/utilix/utilix/tarball.py", line 78, in get_installed_git_repo
    repo = Repo(mod.__path__[0], search_parent_directories=True)
  File "/cvmfs/xenon.opensciencegrid.org/releases/nT/el9.2024.09.1/anaconda/envs/XENONnT_el9.2024.09.1/lib/python3.9/site-packages/git/repo/base.py", line 236, in __init__
    raise NoSuchPathError(epath)
git.exc.NoSuchPathError: /cvmfs/xenon.opensciencegrid.org/releases/nT/el9.2024.09.1/anaconda/envs/XENONnT_el9.2024.09.1/lib/python3.9/site-packages/rucio_clients-32.8.0-py3.9.egg/rucio
```

This is because rucio is not an ordinarily installed package.