### PR TITLE
Fixed unnecessary error raising for DALI jobs

### DIFF
--- a/tests/test_batchq.py
+++ b/tests/test_batchq.py
@@ -3,7 +3,6 @@ from utilix import batchq
 from utilix.batchq import JobSubmission, QOSNotFoundError, FormatError, submit_job
 from utilix.batchq import SERVER
 import pytest
-import os
 from unittest.mock import patch, MagicMock
 import datetime
 import inspect

--- a/tests/test_batchq.py
+++ b/tests/test_batchq.py
@@ -1,30 +1,13 @@
 from pydantic import ValidationError
 from utilix import batchq
 from utilix.batchq import JobSubmission, QOSNotFoundError, FormatError, submit_job
+from utilix.batchq import SERVER
 import pytest
 import os
 from unittest.mock import patch, MagicMock
 import datetime
 import inspect
 import logging
-
-
-# Get the SERVER type
-def get_server_type():
-    hostname = os.uname().nodename
-    if "midway2" in hostname:
-        return "Midway2"
-    elif "midway3" in hostname:
-        return "Midway3"
-    elif "dali" in hostname:
-        return "Dali"
-    else:
-        raise ValueError(
-            f"Unknown server type for hostname {hostname}. Please use midway2, midway3, or dali."
-        )
-
-
-SERVER = get_server_type()
 
 
 def get_partition_and_qos(server):

--- a/utilix/batchq.py
+++ b/utilix/batchq.py
@@ -10,14 +10,29 @@ from pydantic import BaseModel, Field, validator
 from simple_slurm import Slurm  # type: ignore
 from . import logger
 
+# Get the SERVER type
+def get_server_type():
+    hostname = os.uname().nodename
+    if "midway2" in hostname:
+        return "Midway2"
+    elif "midway3" in hostname:
+        return "Midway3"
+    elif "dali" in hostname:
+        return "Dali"
+    else:
+        raise ValueError(
+            f"Unknown server type for hostname {hostname}. Please use midway2, midway3, or dali."
+        )
+        
+SERVER = get_server_type()
+
 USER: Optional[str] = os.environ.get("USER")
 if USER is None:
     raise ValueError("USER environment variable is not set")
 
 SCRATCH_DIR: str = os.environ.get("SCRATCH", ".")
-# SCRATCH_DIR must have write permission
-if not os.access(SCRATCH_DIR, os.W_OK):
-    if 'dali' not in os.environ.get("HOSTNAME"):
+# for non-dali hosts, SCRATCH_DIR must have write permission
+if not os.access(SCRATCH_DIR, os.W_OK) and SERVER != "Dali":
         raise ValueError(
             f"SCRATCH_DIR {SCRATCH_DIR} does not have write permission. "
             "You may need to set SCRATCH_DIR manually in your .bashrc or .bash_profile."

--- a/utilix/batchq.py
+++ b/utilix/batchq.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Field, validator
 from simple_slurm import Slurm  # type: ignore
 from . import logger
 
+
 # Get the SERVER type
 def get_server_type():
     hostname = os.uname().nodename
@@ -23,7 +24,8 @@ def get_server_type():
         raise ValueError(
             f"Unknown server type for hostname {hostname}. Please use midway2, midway3, or dali."
         )
-        
+
+
 SERVER = get_server_type()
 
 USER: Optional[str] = os.environ.get("USER")
@@ -33,10 +35,10 @@ if USER is None:
 SCRATCH_DIR: str = os.environ.get("SCRATCH", ".")
 # for non-dali hosts, SCRATCH_DIR must have write permission
 if not os.access(SCRATCH_DIR, os.W_OK) and SERVER != "Dali":
-        raise ValueError(
-            f"SCRATCH_DIR {SCRATCH_DIR} does not have write permission. "
-            "You may need to set SCRATCH_DIR manually in your .bashrc or .bash_profile."
-        )
+    raise ValueError(
+        f"SCRATCH_DIR {SCRATCH_DIR} does not have write permission. "
+        "You may need to set SCRATCH_DIR manually in your .bashrc or .bash_profile."
+    )
 
 PARTITIONS: List[str] = [
     "dali",

--- a/utilix/batchq.py
+++ b/utilix/batchq.py
@@ -17,10 +17,11 @@ if USER is None:
 SCRATCH_DIR: str = os.environ.get("SCRATCH", ".")
 # SCRATCH_DIR must have write permission
 if not os.access(SCRATCH_DIR, os.W_OK):
-    raise ValueError(
-        f"SCRATCH_DIR {SCRATCH_DIR} does not have write permission. "
-        "You may need to set SCRATCH_DIR manually in your .bashrc or .bash_profile."
-    )
+    if 'dali' not in os.environ.get("HOSTNAME"):
+        raise ValueError(
+            f"SCRATCH_DIR {SCRATCH_DIR} does not have write permission. "
+            "You may need to set SCRATCH_DIR manually in your .bashrc or .bash_profile."
+        )
 
 PARTITIONS: List[str] = [
     "dali",


### PR DESCRIPTION
This error is raised when submitting jobs to DALI compute nodes. However, `SCRATCH_DIR` is only used in `TMP_DIR` a few lines later, which is hardcoded to be at `/dali/lgrandi/{USER}/tmp` for DALI jobs anyway.