### PR TITLE
Fix typo in singularity alias

### DIFF
--- a/utilix/__init__.py
+++ b/utilix/__init__.py
@@ -14,3 +14,4 @@ else:
 
 from .shell import Shell
 from .rundb import DB, xent_collection, xe1t_collection
+from . import mongo_storage

--- a/utilix/batchq.py
+++ b/utilix/batchq.py
@@ -27,9 +27,9 @@ def get_server_type():
 
 
 SERVER = get_server_type()
-SINGULARITY_ALIAS = {"Midway2": "singularity", "Midway3": "apptainer", "Dali": "singularity"}
+SINGULARITY_ALIAS_MAP = {"Midway2": "singularity", "Midway3": "apptainer", "Dali": "singularity"}
 
-alias = SINGULARITY_ALIAS[SERVER]
+SINGULARITY_ALIAS = SINGULARITY_ALIAS_MAP[SERVER]
 
 USER: Optional[str] = os.environ.get("USER")
 if USER is None:


### PR DESCRIPTION
A straightforward fix for a stupid typo... The singularity alias should be a string but not a dict