### PR TITLE
Find repo without `__init__.py`

### DIFF
--- a/utilix/tarball.py
+++ b/utilix/tarball.py
@@ -75,7 +75,7 @@ class Tarball:
         mod = importlib.import_module(package_name)
         # Try initialize git repository
         try:
-            repo = Repo(mod.__path__[0], search_parent_directories=True)
+            repo = Repo(mod.__file__, search_parent_directories=True)
             return repo
         except (OSError, InvalidGitRepositoryError):
             return

--- a/utilix/tarball.py
+++ b/utilix/tarball.py
@@ -2,6 +2,7 @@ import os
 import site
 import tarfile
 import importlib
+from pathlib import Path
 from git import Repo, InvalidGitRepositoryError
 
 
@@ -10,6 +11,9 @@ def filter_tarinfo(tarinfo, git_ignored_files):
 
     # Exclude Git-ignored files
     if any(f in tarinfo.name for f in git_ignored_files):
+        return None
+
+    if ".git" in Path(tarinfo.name).parts:
         return None
 
     # Include the file


### PR DESCRIPTION
If there is no `__init__.py` in the repo (like https://github.com/jelleaalbers/multihist), the `__path__` does not exist.